### PR TITLE
Add required `-B` option when running the probe builder with Internet access

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,61 @@
 
 The probe builder can be used to automatically build kernel modules for [OSS Sysdig](https://github.com/draios/sysdig) as well as the [commercial Sysdig agent](https://sysdig.com/). It can run on any host with Docker installed, including (with some preparation) air-gapped hosts.
 
-The description below assumes that we need to build probes for agent 12.0.0 (substitute the version as required) for RHEL/CentOS kernels. Whenever kernel packages are mentioned, it means kernel-VERSION.rpm and kernel-devel-VERSION.rpm files (with matching VERSION). A similar process can be used for Ubuntu kernels (linux-image-VERSION.deb, linux-headers-VERSION.deb and possibly others) with the -k CustomUbuntu option in place of -k CustomCentOS.
+The description below assumes that we need to build probes for:
+* agent 12.0.0 (substitute the version as required)
+* for RedHat/CentOS kernels (for Ubuntu/Debian kernels use -k CustomUbuntu option instead of -k CustomCentOS).
+
+## Prerequisites
+
+### Downloading kernel packages
+
+To prebuild probes for a particular kernel, you need the headers package for that particular kernel, along
+with its dependencies.
+
+For RedHat-like OSes (RHEL, CentOS, Fedora, etc.), the required packages are usually:
+* `kernel-<VERSION>.rpm`
+* `kernel-devel-<VERSION>.rpm`
+* `kernel-core-<VERSION>.rpm` (if present)
+
+For Debian-like OSes (Debian, Ubuntu, etc.), the required packages are usually:
+* `linux-image-<VERSION>.deb`
+* `linux-headers-<VERSION>.deb`
+
+But please note that the set of required packages varies across distributions and versions, so providing
+an exhaustive list is not possible here.
+
+You can use the `kernel-crawler.py` script to determine the set of packages for a particular kernel.
+To use it, pass a distribution name (one of the following) and, optionally, the specific kernel version
+or its subset.
+
+The output is a list of URLs directly to the kernel packages. For example, to download all the packages
+needed to build the CentOS 4.18.0-305.10.2.el8\_4 kernel, you can run:
+
+    # .../path/to/kernel-crawler.py CentOS 4.18.0-305.10.2.el8_4 | xargs wget -c
+    (...)
+    # ls -la
+    total 61556
+    drwxr-xr-x 2 root root     4096 Aug 12 15:55 .
+    drwxr-xr-x 9 root root     4096 Aug 12 15:53 ..
+    -rw-r--r-- 1 root root  6169556 Jul 20 21:12 kernel-4.18.0-305.10.2.el8_4.x86_64.rpm
+    -rw-r--r-- 1 root root 37552272 Jul 20 21:12 kernel-core-4.18.0-305.10.2.el8_4.x86_64.rpm
+    -rw-r--r-- 1 root root 19290066 Aug 12 15:55 kernel-devel-4.18.0-305.10.2.el8_4.x86_64.rpm
+
+Then you can pass the directory containing the kernel files to the probe builder container
+(`/directory-containing-kernel-packages/` in the examples below).
+
+Distributions supported by the kernel crawler:
+ - AmazonLinux
+ - AmazonLinux2
+ - CentOS
+ - CoreOS
+ - Debian
+ - Fedora
+ - Fedora-Atomic
+ - Ubuntu
+
+Please note that you do *not* need to extract or install the kernel packages on the build host.
+The probe builder works on package files directly and extracts them internally.
 
 ## With internet access
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run --rm \
   -v /a-directory-with-some-free-space/:/workspace \
   -v $(pwd)/agent-libs:/sysdig \
   -v /directory-containing-kernel-packages/:/kernels \
-  sysdig-probe-builder:latest -- \
+  sysdig-probe-builder:latest -B -- \
   -p sysdigcloud-probe -v 12.0.0 -k CustomCentOS
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Running an on-prem probe builder
 
-The probe builder can be used to automatically build kernel modules for [OSS Sysdig](https://github.com/draios/sysdig) as well as the [commercial Sysdig agent](https://sysdig.com/). It can run on any host with Docker installed, including (with some preparation) air-gapped hosts.
+The probe builder can be used to automatically build kernel modules for the [commercial Sysdig agent](https://sysdig.com/). It can run on any host with Docker installed, including (with some preparation) air-gapped hosts.
 
 The description below assumes that we need to build probes for:
 * agent 12.0.0 (substitute the version as required)

--- a/build-probe-binaries
+++ b/build-probe-binaries
@@ -102,6 +102,10 @@ Options:
 		coreos_developer_container.VERSION.bin.bz2, where VERSION is
 		the CoreOS release (e.g. 2345.0.0).
 
+	-K KERNEL_BASEDIR
+		Pass KERNEL_BASEDIR as the directory containing the kernels to the builder
+		containers. This is probably only useful when running this script in a container
+
 	-p PROBE_NAME
 		The resulting module name (e.g. sysdig-probe for OSS sysdig).
 
@@ -144,7 +148,8 @@ EOF
 
 BASEDIR=$(pwd)
 DOCKER_BASEDIR=$BASEDIR
-while getopts ":a:A:b:B:d:k:p:r:s:t:v:" opt
+KERNEL_BASEDIR=$BASEDIR
+while getopts ":a:A:b:B:d:k:K:p:r:s:t:v:" opt
 do
 	case "$opt" in
 		a) ARTIFACTORY_SERVER=$OPTARG;;
@@ -154,6 +159,8 @@ do
 		   RUNNING_IN_DOCKER=1;;
 		d) DOWNLOAD_CONCURRENCY=$OPTARG;;
 		k) KERNEL_TYPE=$OPTARG;;
+		K) KERNEL_BASEDIR=$OPTARG
+		   RUNNING_IN_DOCKER=1;;
 		p) PROBE_NAME=$OPTARG;;
 		r) RETRIES=$OPTARG;;
 		s) SYSDIG_DIR=$OPTARG;;
@@ -501,7 +508,13 @@ function ubuntu_build {
 		else
 			echo "Unpacking $DEB to $TARGET"
 			mkdir -p $TARGET
-			docker run --rm -v $(pwd)/$DEB:/$DEB:ro -v $(pwd)/$TARGET:/output:rw ubuntu:latest dpkg -x /$DEB /output
+			if [ -n "$RUNNING_IN_DOCKER" ]
+			then
+				UBUNTU_KERNEL_DEB=$KERNEL_BASEDIR/${DEB#/*/}
+			else
+				UBUNTU_KERNEL_DEB=$(pwd)/$DEB
+			fi
+			docker run --rm -v $UBUNTU_KERNEL_DEB:/$DEB:ro -v $DOCKER_BASEDIR/$TARGET:/output:rw ubuntu:latest dpkg -x /$DEB /output
 			touch $MARKER
 		fi
 	done

--- a/kernel-crawler.py
+++ b/kernel-crawler.py
@@ -74,7 +74,7 @@ repos = {
             # Finally, we need to inspect every page for packages we need.
             # Again, this is an XPath + Regex query so use the regex if you want
             # to limit the number of packages reported.
-            "page_pattern" : "/html/body//a[regex:test(@href, '^kernel-(devel-)?[0-9].*\.rpm$')]/@href"
+            "page_pattern" : "/html/body//a[regex:test(@href, '^kernel-(devel-|core-)?[0-9].*\.rpm$')]/@href"
         },
 
         {
@@ -84,7 +84,7 @@ repos = {
                 "os/x86_64/Packages/",
                 "updates/x86_64/Packages/"
             ],
-            "page_pattern" : "//body//table/tr/td/a[regex:test(@href, '^kernel-(devel-)?[0-9].*\.rpm$')]/@href"
+            "page_pattern" : "//body//table/tr/td/a[regex:test(@href, '^kernel-(devel-|core-)?[0-9].*\.rpm$')]/@href"
         }
     ],
 

--- a/kernel-crawler.py
+++ b/kernel-crawler.py
@@ -62,13 +62,14 @@ repos = {
             # This is the XPath + Regex (optional) for analyzing the `root`
             # page and discover possible distro versions. Use the regex if you
             # want to limit the version release
-            "discovery_pattern" : "/html/body//pre/a[regex:test(@href, '^6|^7.*$')]/@href",
+            "discovery_pattern" : "/html/body//pre/a[regex:test(@href, '^6|^7|^8.*$')]/@href",
 
             # Once we have found every version available, we need to know were
             # to go inside the tree to find packages we need (HTML pages)
             "subdirs" : [
                 "os/x86_64/Packages/",
-                "updates/x86_64/Packages/"
+                "updates/x86_64/Packages/",
+                "BaseOS/x86_64/os/Packages/"
             ],
 
             # Finally, we need to inspect every page for packages we need.
@@ -79,10 +80,11 @@ repos = {
 
         {
             "root" : "http://vault.centos.org/",
-            "discovery_pattern" : "//body//table/tr/td/a[regex:test(@href, '^6|^7.*$')]/@href",
+            "discovery_pattern" : "//body//table/tr/td/a[regex:test(@href, '^6|^7|^8.*$')]/@href",
             "subdirs" : [
                 "os/x86_64/Packages/",
-                "updates/x86_64/Packages/"
+                "updates/x86_64/Packages/",
+                "BaseOS/x86_64/os/Packages/"
             ],
             "page_pattern" : "//body//table/tr/td/a[regex:test(@href, '^kernel-(devel-|core-)?[0-9].*\.rpm$')]/@href"
         }

--- a/kernel-crawler.py
+++ b/kernel-crawler.py
@@ -390,13 +390,18 @@ urls = set()
 URL_TIMEOUT=30
 
 if len(sys.argv) < 2 or not sys.argv[1] in repos:
-    sys.stderr.write("Usage: " + sys.argv[0] + " <distro>\n")
+    sys.stderr.write("Usage: " + sys.argv[0] + " <distro> [version]\n")
     sys.stderr.write("Available distros:\n")
     for d in sorted(repos):
         sys.stderr.write(" - {}\n".format(d))
     sys.exit(1)
 
 distro = sys.argv[1]
+try:
+    version_filter = sys.argv[2]
+    sys.stderr.write('Looking for packages matching "{}"\n'.format(version_filter))
+except IndexError:
+    version_filter = ''
 
 #
 # Navigate the `repos` tree and look for packages we need that match the
@@ -450,4 +455,5 @@ for repo in repos[distro]:
 # Print URLs to stdout
 #
 for url in urls:
-    print(url)
+    if version_filter in url:
+        print(url)

--- a/kernel-crawler.py
+++ b/kernel-crawler.py
@@ -399,6 +399,8 @@ if len(sys.argv) < 2 or not sys.argv[1] in repos:
 distro = sys.argv[1]
 try:
     version_filter = sys.argv[2]
+    if distro == 'Ubuntu' and version_filter.endswith('-generic'):
+        version_filter = version_filter[:-len('-generic')]
     sys.stderr.write('Looking for packages matching "{}"\n'.format(version_filter))
 except IndexError:
     version_filter = ''

--- a/main-builder-entrypoint.sh
+++ b/main-builder-entrypoint.sh
@@ -63,7 +63,7 @@ build_probes()
 	KERNELS_SRC=$(get_host_mount /kernels)  
 
 	cd /workspace
-	/builder/build-probe-binaries -B $WORKSPACE_SRC -s $SYSDIG_SRC -b "$BUILDER_IMAGE_PREFIX" "$@" /kernels/*
+	/builder/build-probe-binaries -B $WORKSPACE_SRC -K $KERNELS_SRC -s $SYSDIG_SRC -b "$BUILDER_IMAGE_PREFIX" "$@" /kernels/*
 }
 
 prepare_builders()


### PR DESCRIPTION
(also, switch to the vault CentOS repo for v6)