### PR TITLE
Build eBPF probes along with kernel modules

### DIFF
--- a/Dockerfile.centos-gcc10.3
+++ b/Dockerfile.centos-gcc10.3
@@ -13,6 +13,8 @@ RUN yum -y install \
 	elfutils-devel \
 	findutils \
 	kmod \
+	clang \
+	llvm \
 	python-lxml && yum clean all
 
 # amazonlinux2 uses a wacky version of gcc which puts wrappers on stuff (probably from

--- a/Dockerfile.centos-gcc11.0
+++ b/Dockerfile.centos-gcc11.0
@@ -13,6 +13,8 @@ RUN yum -y install \
 	elfutils-devel \
 	findutils \
 	kmod \
+	clang \
+	llvm \
 	python-lxml && yum clean all
 
 ADD builder-entrypoint.sh /

--- a/Dockerfile.centos-gcc11.0
+++ b/Dockerfile.centos-gcc11.0
@@ -1,0 +1,20 @@
+FROM fedora:34
+
+RUN yum -y install \
+	wget \
+	git \
+	gcc \
+	gcc-c++ \
+	autoconf \
+	bison \
+	flex \
+	make \
+	cmake \
+	elfutils-devel \
+	findutils \
+	kmod \
+	python-lxml && yum clean all
+
+ADD builder-entrypoint.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]

--- a/Dockerfile.centos-gcc7.3
+++ b/Dockerfile.centos-gcc7.3
@@ -13,6 +13,8 @@ RUN yum -y install \
 	elfutils-devel \
 	findutils \
 	kmod \
+	clang \
+	llvm \
 	python-lxml && yum clean all
 
 ADD builder-entrypoint.sh /

--- a/Dockerfile.centos-gcc8.3
+++ b/Dockerfile.centos-gcc8.3
@@ -13,6 +13,8 @@ RUN yum -y install \
 	elfutils-devel \
 	findutils \
 	kmod \
+	clang \
+	llvm \
 	python-lxml && yum clean all
 
 ADD builder-entrypoint.sh /

--- a/Dockerfile.centos-gcc9.2
+++ b/Dockerfile.centos-gcc9.2
@@ -13,6 +13,8 @@ RUN yum -y install \
 	elfutils-devel \
 	findutils \
 	kmod \
+	clang \
+	llvm \
 	python-lxml && yum clean all
 
 ADD builder-entrypoint.sh /

--- a/Dockerfile.debian-gcc6.3
+++ b/Dockerfile.debian-gcc6.3
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 	libc6-dev \
 	make \
 	pkg-config \
+	clang \
+	llvm \
 	&& apt-get clean
 
 ADD builder-entrypoint.sh /

--- a/Dockerfile.debian-gcc8.3
+++ b/Dockerfile.debian-gcc8.3
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 	libc6-dev \
 	make \
 	pkg-config \
+	clang \
+	llvm \
 	&& apt-get clean
 
 ADD builder-entrypoint.sh /

--- a/Dockerfile.ubuntu-gcc10.3
+++ b/Dockerfile.ubuntu-gcc10.3
@@ -11,6 +11,8 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu/ hirsute-proposed restricted main
 		libelf-dev \
 		make \
 		pkg-config \
+		clang \
+		llvm \
 		&& apt-get clean
 
 ADD builder-entrypoint.sh /

--- a/Dockerfile.ubuntu-gcc11.2
+++ b/Dockerfile.ubuntu-gcc11.2
@@ -11,6 +11,8 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu/ impish-proposed restricted main 
 		libelf-dev \
 		make \
 		pkg-config \
+		clang \
+		llvm \
 		&& apt-get clean
 
 ADD builder-entrypoint.sh /

--- a/Dockerfile.ubuntu-gcc7.4
+++ b/Dockerfile.ubuntu-gcc7.4
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 	libelf-dev \
 	make \
 	pkg-config \
+	clang \
+	llvm \
 	&& apt-get clean
 
 ADD builder-entrypoint.sh /

--- a/build-probe-binaries
+++ b/build-probe-binaries
@@ -394,7 +394,35 @@ function build_probe_impl {
 		-e HASH=$HASH \
 		-e HASH_ORIG=$HASH_ORIG \
 		--name $CONTAINER_NAME \
-		$IMAGE_NAME || return 1
+		$IMAGE_NAME "$@" || return 1
+}
+
+function build_probe_bpf {
+	PROBE_ID=$PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o
+
+	# Skip Kernel 4.15.0-29 because probe does not build against it
+	if [ $KERNEL_RELEASE-$HASH = "4.15.0-29-generic-ea0aa038a6b9bdc4bb42152682bba6ce" -o \
+		$KERNEL_RELEASE-$HASH = "5.8.0-1023-aws-3f7746be1bef4c3f68f5465d8453fa4d" ]; then
+		echo "Temporarily skipping BPF $PROBE_ID"
+		return
+	fi
+
+	if [ -f $BASEDIR/output/$PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o ] &&
+	   [ -f $BASEDIR/output/$PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.o ]; then
+		echo "Skipping BPF $PROBE_ID (already built)"
+		return
+	fi
+
+	LOG=$(mktemp /tmp/log.XXXXXX)
+	if ! build_probe_impl bpf &> $LOG
+	then
+		(echo "BPF Build for $PROBE_ID failed"; cat $LOG) | tee -a $FAIL_LOG
+		FAILED=1
+	else
+		echo "BPF Build for $PROBE_ID successful"
+		cat $LOG
+	fi
+	rm -f $LOG
 }
 
 function build_probe {
@@ -541,6 +569,7 @@ function ubuntu_build {
 		KERNEL_RELEASE=$KERNEL_VERSION
 		echo "Building probe for Ubuntu kernel $KERNEL_VERSION ($KERNEL_RELEASE_FULL)"
 		build_probe
+		build_probe_bpf
 	done
 }
 
@@ -581,6 +610,7 @@ function rhel_build {
 		export KERNELDIR=$BASEDIR/$TARGET/usr/src/kernels/$KERNEL_RELEASE
 		echo "Building probe for CentOS kernel $KERNEL_RELEASE"
 		build_probe
+		build_probe_bpf
 	done
 }
 
@@ -682,6 +712,7 @@ function debian_build {
 		KERNEL_RELEASE=$KERNEL_ARCH_RELEASE
 		echo "Building probe for Debian kernel $KERNEL_ARCH_RELEASE"
 		build_probe
+		build_probe_bpf
 	done
 }
 

--- a/build-probe-binaries
+++ b/build-probe-binaries
@@ -413,16 +413,16 @@ function build_probe {
 		return
 	fi
 
-    LOG=$(mktemp /tmp/log.XXXXXX)
-    if ! build_probe_impl &> $LOG
-    then
-        (echo "Build for $PROBE_ID failed"; cat $LOG) | tee -a $FAIL_LOG
-        FAILED=1
-    else
+	LOG=$(mktemp /tmp/log.XXXXXX)
+	if ! build_probe_impl &> $LOG
+	then
+		(echo "Build for $PROBE_ID failed"; cat $LOG) | tee -a $FAIL_LOG
+		FAILED=1
+	else
 		echo "Build for $PROBE_ID successful"
 		cat $LOG
-    fi
-    rm -f $LOG
+	fi
+	rm -f $LOG
 }
 
 function coreos_build {

--- a/builder-entrypoint.sh
+++ b/builder-entrypoint.sh
@@ -14,31 +14,45 @@ set -euo pipefail
 
 ARCH=$(uname -m)
 
-if [[ -f "${KERNELDIR}/scripts/gcc-plugins/stackleak_plugin.so" ]]; then
-	echo "Rebuilding gcc plugins for ${KERNELDIR}"
-	(cd "${KERNELDIR}" && make gcc-plugins)
-fi
+build_kmod() {
+	if [[ -f "${KERNELDIR}/scripts/gcc-plugins/stackleak_plugin.so" ]]; then
+		echo "Rebuilding gcc plugins for ${KERNELDIR}"
+		(cd "${KERNELDIR}" && make gcc-plugins)
+	fi
 
-echo Building $PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
+	echo Building $PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
 
-mkdir -p /build/sysdig
-cd /build/sysdig
+	mkdir -p /build/sysdig
+	cd /build/sysdig
 
-cmake -DCMAKE_BUILD_TYPE=Release -DPROBE_NAME=$PROBE_NAME -DPROBE_VERSION=$PROBE_VERSION -DPROBE_DEVICE_NAME=$PROBE_DEVICE_NAME -DCREATE_TEST_TARGETS=OFF /build/probe/sysdig
-make driver
-strip -g driver/$PROBE_NAME.ko
+	cmake -DCMAKE_BUILD_TYPE=Release -DPROBE_NAME=$PROBE_NAME -DPROBE_VERSION=$PROBE_VERSION -DPROBE_DEVICE_NAME=$PROBE_DEVICE_NAME -DCREATE_TEST_TARGETS=OFF /build/probe/sysdig
+	make driver
+	strip -g driver/$PROBE_NAME.ko
 
-KO_VERSION=$(/sbin/modinfo driver/$PROBE_NAME.ko | grep vermagic | tr -s " " | cut -d " " -f 2)
-if [ "$KO_VERSION" != "$KERNEL_RELEASE" ]; then
-	echo "Corrupted probe, KO_VERSION " $KO_VERSION ", KERNEL_RELEASE " $KERNEL_RELEASE
-	exit 1
-fi
+	KO_VERSION=$(/sbin/modinfo driver/$PROBE_NAME.ko | grep vermagic | tr -s " " | cut -d " " -f 2)
+	if [ "$KO_VERSION" != "$KERNEL_RELEASE" ]; then
+		echo "Corrupted probe, KO_VERSION " $KO_VERSION ", KERNEL_RELEASE " $KERNEL_RELEASE
+		exit 1
+	fi
 
-cp driver/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
-cp driver/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko
+	cp driver/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
+	cp driver/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko
+}
 
-if type -p clang > /dev/null
-then
-	make -C /build/probe/sysdig/driver/bpf
-	cp /build/probe/sysdig/driver/bpf/probe.o $OUTPUT/$PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
-fi
+
+build_bpf() {
+	if ! type -p clang > /dev/null
+	then
+		echo "clang not available, not building eBPF probe $PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o"
+	else
+		echo "Building eBPF probe $PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o"
+		make -C /build/probe/sysdig/driver/bpf
+		cp /build/probe/sysdig/driver/bpf/probe.o $OUTPUT/$PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o
+	fi
+}
+
+case "${1:-}" in
+	bpf) build_bpf;;
+	"") build_kmod;;
+	*) exit 1;;
+esac

--- a/builder-entrypoint.sh
+++ b/builder-entrypoint.sh
@@ -36,3 +36,9 @@ fi
 
 cp driver/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
 cp driver/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko
+
+if type -p clang > /dev/null
+then
+	make -C /build/probe/sysdig/driver/bpf
+	cp /build/probe/sysdig/driver/bpf/probe.o $OUTPUT/$PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
+fi

--- a/kernel-crawler.py
+++ b/kernel-crawler.py
@@ -148,7 +148,7 @@ repos = {
 
     "Fedora" : [
         {
-            "root" : "https://mirrors.edge.kernel.org/fedora/releases/",
+            "root" : "https://mirrors.kernel.org/fedora/releases/",
             "discovery_pattern": "/html/body//a[regex:test(@href, '^[3-9][0-9]/$')]/@href",
             "subdirs" : [
                 "Everything/x86_64/os/Packages/k/"
@@ -157,7 +157,7 @@ repos = {
         },
 
         {
-            "root" : "https://mirrors.edge.kernel.org/fedora/updates/",
+            "root" : "https://mirrors.kernel.org/fedora/updates/",
             "discovery_pattern": "/html/body//a[regex:test(@href, '^[3-9][0-9]/$')]/@href",
             "subdirs" : [
                 "x86_64/Packages/k/"
@@ -166,7 +166,7 @@ repos = {
         },
 
         {
-            "root" : "https://mirrors.edge.kernel.org/fedora/updates/",
+            "root" : "https://mirrors.kernel.org/fedora/updates/",
             "discovery_pattern": "/html/body//a[regex:test(@href, '^[3-9][0-9]/$')]/@href",
             "subdirs" : [
                 "Everything/x86_64/Packages/k/"


### PR DESCRIPTION
The eBPF probe is built if clang is available in the builder image, otherwise it's (mostly silently) skipped

clang is installed in the following builders:
* debian:buster
* debian:stretch
* fedora:27
* fedora:29
* fedora:31
* fedora:32
* fedora:34
* ubuntu:18.04
* ubuntu:hirsute-20210119
* ubuntu:impish

While CentOS7 technically supports eBPF, the probe doesn't build with the clang version shipping with CentOS7. If it's important, we can consider some workaround (upgraded clang or some hacks when selecting the builder)