### PR TITLE
[SSPROD-8709] Also consider linux-modules-* as a build trigger

### DIFF
--- a/build-probe-binaries
+++ b/build-probe-binaries
@@ -563,7 +563,7 @@ function ubuntu_build {
 
 	for DEB in "$@"
 	do
-		if [[ $(basename $DEB) != "linux-image-"*".deb" ]]
+		if [[ $(basename $DEB) != "linux-image-"*".deb" && $(basename $DEB) != "linux-modules-"*".deb" ]]
 		then
 			continue
 		fi


### PR DESCRIPTION
We no longer download many of the linux-image-* packages
so we need the linux-modules-* ones to trigger the build.

This means we'll potentially run some builds twice but
the second one should immediately notice that the probes
are already built and exit.