### PR TITLE
Add a Debian bullseye builder

### DIFF
--- a/Dockerfile.debian-gcc10.2
+++ b/Dockerfile.debian-gcc10.2
@@ -1,0 +1,18 @@
+FROM debian:bullseye
+
+RUN apt-get update && apt-get -y --no-install-recommends install \
+	cmake \
+	g++ \
+	git \
+	kmod \
+	libc6-dev \
+	make \
+	pkg-config \
+	clang \
+	llvm \
+	&& apt-get clean
+
+ADD builder-entrypoint.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]
+


### PR DESCRIPTION
This should ship with `gcc-10` already present, so we don't need to symlink it manually