### PR TITLE
[SSPROD-9627] Enhance build-probe-binaries Debian logic to handle new linux-headers Makefile format

### DIFF
--- a/Dockerfile.debian-gcc10.2
+++ b/Dockerfile.debian-gcc10.2
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:bullseye
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
 	cmake \
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 	libelf-dev \
 	make \
 	pkg-config \
+	clang \
+	llvm \
 	&& apt-get clean
 
 ADD builder-entrypoint.sh /

--- a/Dockerfile.debian-gcc6.3
+++ b/Dockerfile.debian-gcc6.3
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 	git \
 	kmod \
 	libc6-dev \
+	libelf-dev \
 	make \
 	pkg-config \
 	clang \

--- a/Dockerfile.debian-gcc8.3
+++ b/Dockerfile.debian-gcc8.3
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 	git \
 	kmod \
 	libc6-dev \
+	libelf-dev \
 	make \
 	pkg-config \
 	clang \

--- a/build-probe-binaries
+++ b/build-probe-binaries
@@ -653,7 +653,7 @@ function debian_build {
 			touch $MARKER
 		fi
 		set +e
-		KBUILD_PACKAGE=$(ls $DISTRO/linux-kbuild-${KERNEL_MAJOR}_*.deb 2>/dev/null | tail -1)
+		KBUILD_PACKAGE=$(ls $@ 2>/dev/null | grep "linux-kbuild-${KERNEL_MAJOR}_.*.deb" | tail -1)
 		set -e
 		if [ -n "$KBUILD_PACKAGE" ]
 		then

--- a/build-probe-binaries
+++ b/build-probe-binaries
@@ -719,7 +719,8 @@ function debian_build {
 			cat $MAKEFILE.sysdig-orig | \
 			sed '0,/MAKEARGS.*$/s||MAKEARGS := -C '"${CONTAINER_KERNELDIR_COMMON}"' O='"${CONTAINER_KERNELDIR}"'|' | \
 			sed 's/@://' | \
-			sed 's|$(cmd) %.*$|$(cmd) : all|' > $MAKEFILE
+			sed 's|$(cmd) %.*$|$(cmd) : all|' |
+			sed 's|^include .*$|include '"${CONTAINER_KERNELDIR_COMMON}"'/Makefile|' > $MAKEFILE
 		fi
 
 		# impedance mismatch


### PR DESCRIPTION
Fixes to allow build-probe-binaries -k CustomDebian to work on Debian 11:
- Linux headers for Debian 11 use a new format for the architecture-specific Makefile.
  Enhance the Makefile relocation patching logic to handle this new format as well as the old one.
- Fix build-probe-binaries Debian linux-kbuild finder logic to accomodate package location
  in the CustomDebian case.
- Fix Debian Dockerfiles to install libelf-dev package (like Ubuntu Dockerfiles)
- Add new Dockerfile.debian-gcc10.2, to handle the version of GCC available in Debian 11.
