### PR TITLE
Install python3 in the builder container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,12 @@ RUN apk add \
 	git \
 	jq \
 	multipath-tools \
+	python3 \
 	py3-lxml \
 	wget \
     docker
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
 ADD . /builder
 WORKDIR /builder


### PR DESCRIPTION
This is a single commit from https://github.com/draios/probe-builder/pull/18/ that should be as non-controversial as possible. I'd like to:
1. merge this (I don't believe there should ever be a reason to revert it)
2. switch the jenkins job to build using a docker container (we can easily back the change out in case of any issues)
3. merge the rest of https://github.com/draios/probe-builder/pull/18/ (and then subsequent PRs) without having to touch the jenkins job again