### PR TITLE
Skip eBPF probes for Fedora 35, fix Fedora 34 eBPF

### DIFF
--- a/Dockerfile.centos-gcc11.2
+++ b/Dockerfile.centos-gcc11.2
@@ -13,8 +13,6 @@ RUN yum -y install \
 	elfutils-devel \
 	findutils \
 	kmod \
-	clang \
-	llvm \
 	python-lxml && yum clean all
 
 ADD builder-entrypoint.sh /

--- a/Dockerfile.fc34
+++ b/Dockerfile.fc34
@@ -1,0 +1,22 @@
+FROM fedora:34
+
+RUN yum -y install \
+	wget \
+	git \
+	gcc \
+	gcc-c++ \
+	autoconf \
+	bison \
+	flex \
+	make \
+	cmake \
+	elfutils-devel \
+	findutils \
+	kmod \
+	clang \
+	llvm \
+	python-lxml && yum clean all
+
+ADD builder-entrypoint.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]

--- a/build-probe-binaries
+++ b/build-probe-binaries
@@ -278,7 +278,28 @@ function build_probe_impl {
 		DOCKERFILE_TAG=$DOCKER_BUILDER
 
 		echo "Forced use of builder $DOCKERFILE_TAG"
-	elif [ -n "${BUILDER_DISTRO:-}" ]
+	elif [ -e $KERNELDIR/include/generated/autoconf.h ]
+	then
+		# Try to find a distro-specific builder based on the version
+		# embedded in the header of autoconf.h
+		# /*
+		#  *
+		#  * Automatically generated file; DO NOT EDIT.
+		#  * Linux/x86_64 5.15.5-100.fc34.x86_64 Kernel Configuration
+		#  *
+		#  */
+		DISTRO_RELEASE=$(grep -Po '(?<=\.)fc[0-9]+(?=\..*Kernel Configuration$)' $KERNELDIR/include/generated/autoconf.h)
+		DOCKERFILE=$BUILDER_SOURCE/Dockerfile.$DISTRO_RELEASE
+		DOCKERFILE_TAG=${DOCKERFILE#$BUILDER_SOURCE/Dockerfile.}
+
+		if [ ! -e "$DOCKERFILE" ]
+		then
+			echo "Could not find distro-specific builder for $DISTRO_RELEASE, falling back to gcc version selection"
+			DOCKERFILE=
+		fi
+	fi
+
+	if [ -n "${BUILDER_DISTRO:-}" ] && [ -z "${DOCKERFILE:-}" ]
 	then
 		# Try to find the gcc version used to build this particular kernel
 		# Check CONFIG_GCC_VERSION=90201 in the kernel config first


### PR DESCRIPTION
###    [SMAGENT-3278] Don't install clang in Fedora 35 container

    The eBPF probe builds successfully with clang 13 but then fails
    the verifier test upon loading.

###    [SMAGENT-3278] Use specific builder for Fedora 34

    Fedora 34 and 35 have the same gcc version (at least at this point
    in time) but are otherwise incompatible:
    - fc34 can't build probes for fc35 kernels because fc35 needs a newer glibc
    - fc35 can't build eBPF probes (at all) because its clang is too new

    1. Try to parse the kernel version to look for distro-specific tags.
    If one is found, look for a matching dockerfile. If there is one, use it.
    Otherwise, fall back to gcc version based choice.

    2. Add a fc34 builder

[SMAGENT-3278]: https://sysdig.atlassian.net/browse/SMAGENT-3278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SMAGENT-3278]: https://sysdig.atlassian.net/browse/SMAGENT-3278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ