### PR TITLE
Dockerfile: fix building of debian probes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add \
 	multipath-tools \
 	python3 \
 	py3-lxml \
+	sed \
 	wget \
     docker
 


### PR DESCRIPTION
add a non-busybox sed to the container used to call
the top-level script build-probe-binaries

This is necessary to patch the Makefiles used when
building debian probes.