### PR TITLE
fix ubuntu missing kernels, take2

### DIFF
--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -127,7 +127,7 @@ def build(builder_image_prefix,
 
     kernels = distro_obj.get_kernels(workspace, package, download_config)
     kernel_dirs = distro_builder.unpack_kernels(workspace, distro.distro, kernels)
-    for release, target in kernel_dirs.items():
+    for release, target in kernel_dirs:
         distro_builder.build_kernel(workspace, probe, distro.builder_distro, release, target)
 
 

--- a/probe_builder/builder/distro/centos.py
+++ b/probe_builder/builder/distro/centos.py
@@ -14,11 +14,11 @@ class CentosBuilder(DistroBuilder):
     RPM_KERNEL_RELEASE_RE = re.compile(r'^kernel-(uek-)?(core-|devel-|modules-)?(?P<release>.*)\.rpm$')
 
     def unpack_kernels(self, workspace, distro, kernels):
-        kernel_dirs = dict()
+        kernel_dirs = list()
 
         for release, rpms in kernels.items():
             target = workspace.subdir('build', distro, release)
-            kernel_dirs[release] = target
+            kernel_dirs.append((release, target))
 
             for rpm in rpms:
                 rpm_basename = os.path.basename(rpm)

--- a/probe_builder/builder/distro/debian.py
+++ b/probe_builder/builder/distro/debian.py
@@ -25,7 +25,7 @@ class DebianBuilder(DistroBuilder):
             os.symlink(build_link_target, build_link_path)
 
     def unpack_kernels(self, workspace, distro, kernels):
-        kernel_dirs = dict()
+        kernel_dirs = list()
 
         for release, debs in kernels.items():
             # we can no longer use '-' as the separator, since now also have variant
@@ -35,18 +35,17 @@ class DebianBuilder(DistroBuilder):
             release = release.replace(':', '-')
 
             target = workspace.subdir('build', distro, version)
-            kernel_dirs[release] = target
 
             try:
                 for deb in debs:
                     deb_basename = os.path.basename(deb)
                     marker = os.path.join(target, '.' + deb_basename)
                     toolkit.unpack_deb(workspace, deb, target, marker)
+                kernel_dirs.append((release, target))
             except:
                 traceback.print_exc()
-                del kernel_dirs[release]
 
-        for release, target in kernel_dirs.items():
+        for release, target in kernel_dirs:
             kerneldir = self.get_kernel_dir(workspace, release, target)
 
             base_path = workspace.subdir(target)

--- a/probe_builder/builder/distro/flatcar.py
+++ b/probe_builder/builder/distro/flatcar.py
@@ -16,11 +16,11 @@ logger = logging.getLogger(__name__)
 
 class FlatcarBuilder(DistroBuilder):
     def unpack_kernels(self, workspace, distro, kernels):
-        kernel_dirs = dict()
+        kernel_dirs = list()
 
         for release, dev_containers in kernels.items():
             target = workspace.subdir('build', distro, release)
-            kernel_dirs[release] = target
+            kernel_dirs.append((release, target))
 
             for dev_container in dev_containers:
                 dev_container_basename = os.path.basename(dev_container)

--- a/probe_builder/builder/distro/ubuntu.py
+++ b/probe_builder/builder/distro/ubuntu.py
@@ -91,13 +91,13 @@ class UbuntuBuilder(DistroBuilder):
             if m:
                 release = m.group('release')
                 version_to_releases.setdefault(version, set()).add(release)
-                releases.setdefault(release, []).append(deb)
+                releases.setdefault((release, version), []).append(deb)
             else:
                 version_files.setdefault(version, []).append(deb)
 
         for version, release_ids in version_to_releases.items():
             for release_id in release_ids:
-                release_files = releases[release_id]
+                release_files = releases[(release_id, version)]
                 # add all the shared files that end up in the same directory
                 release_files.extend(version_files.get(version, []))
                 kernels.append((release_id, release_files))

--- a/probe_builder/builder/distro/ubuntu.py
+++ b/probe_builder/builder/distro/ubuntu.py
@@ -15,8 +15,7 @@ class UbuntuBuilder(DistroBuilder):
     KERNEL_RELEASE_RE = re.compile(r'(?P<release>[0-9]\.[0-9]+\.[0-9]+-[0-9]+-[a-z0-9-]+)')
 
     def unpack_kernels(self, workspace, distro, kernels):
-        kernel_dirs = dict()
-
+        kernel_dirs = list()
         for release, debs in kernels:
             # we don't have the version handy, so gather it from all the package
             # names in the release. these all should match but at this point we can
@@ -39,7 +38,7 @@ class UbuntuBuilder(DistroBuilder):
                         ))
 
             target = workspace.subdir('build', distro, version[0], version[1])
-            kernel_dirs[release] = target
+            kernel_dirs.append((release, target))
 
             for deb in debs:
                 deb_basename = os.path.basename(deb)


### PR DESCRIPTION
- builder: allow multiple target directories for the same release
- ubuntu: treat each package version as a separate release
