### PR TITLE
fix eBPF build for Fedora 35

### DIFF
--- a/Dockerfile.centos-gcc11.2
+++ b/Dockerfile.centos-gcc11.2
@@ -13,6 +13,8 @@ RUN yum -y install \
 	elfutils-devel \
 	findutils \
 	kmod \
+	clang \
+	llvm \
 	python-lxml && yum clean all
 
 ADD builder-entrypoint.sh /


### PR DESCRIPTION
Re-add clang and llvm to the builder container for Fedora 35,
which were initially removed because at the time they would
generate code that would not pass the verifier test upon loading.

The version now present in the image does not seem to suffer from
this problem anymore, so re-add them.

This reverts commit 66724e2f0aa069f799f9165cae8d4b9e8bbfa9c8.