### PR TITLE
add support for AmazonLinux 2022

### DIFF
--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -80,6 +80,7 @@ class LocalDistro(object):
 CLI_DISTROS = {
     'AmazonLinux': CrawlDistro('amazonlinux', 'centos', 'AmazonLinux'),
     'AmazonLinux2': CrawlDistro('amazonlinux2', 'centos', 'AmazonLinux2'),
+    'AmazonLinux2022': CrawlDistro('amazonlinux2022', 'centos', 'AmazonLinux2022'),
     'CentOS': CrawlDistro('centos', 'centos', 'CentOS'),
     'Debian': CrawlDistro('debian', 'debian', 'Debian'),
     'Fedora': CrawlDistro('fedora', 'centos', 'Fedora'),

--- a/probe_builder/kernel_crawler/__init__.py
+++ b/probe_builder/kernel_crawler/__init__.py
@@ -1,4 +1,4 @@
-from .amazonlinux import AmazonLinux1Mirror, AmazonLinux2Mirror
+from .amazonlinux import AmazonLinux1Mirror, AmazonLinux2Mirror, AmazonLinux2022Mirror
 from .centos import CentosMirror
 from .fedora import FedoraMirror
 from .oracle import Oracle6Mirror, Oracle7Mirror, Oracle8Mirror
@@ -12,6 +12,7 @@ from .flatcar import FlatcarMirror
 DISTROS = {
     'AmazonLinux': AmazonLinux1Mirror,
     'AmazonLinux2': AmazonLinux2Mirror,
+    'AmazonLinux2022': AmazonLinux2022Mirror,
     'CentOS': CentosMirror,
     'Fedora': FedoraMirror,
     'Oracle6': Oracle6Mirror,

--- a/probe_builder/kernel_crawler/amazonlinux.py
+++ b/probe_builder/kernel_crawler/amazonlinux.py
@@ -65,6 +65,7 @@ class AmazonLinux2022Mirror(repo.Distro):
     # docker run -it --rm amazonlinux:2022 python3 -c 'import dnf, json; db = dnf.dnf.Base(); print(json.dumps(db.conf.substitutions, indent=2))'
     AL2022_REPOS = [
         '2022.0.20220202',
+        '2022.0.20220315',
     ]
 
     def __init__(self):


### PR DESCRIPTION
Notice how, as of today, we only have one kernel version,
shared by all AmazonLinux 2022 AMIs: 5.10.75-82.359.amzn2022.x86_64