### PR TITLE
refine kernel version filtering

### DIFF
--- a/probe_builder/builder/distro/base_builder.py
+++ b/probe_builder/builder/distro/base_builder.py
@@ -102,8 +102,8 @@ class DistroBuilder(object):
     def batch_packages(self, kernel_files):
         raise NotImplementedError
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None):
-        kernels = crawl_kernels(crawler_distro)
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, filter=''):
+        kernels = crawl_kernels(crawler_distro, filter)
         try:
             os.makedirs(workspace.subdir(distro.distro))
         except OSError as exc:


### PR DESCRIPTION
add -f <filter> option to the build command, so that filter could be
applied to building in addition to crawling.
Notice how for 'crawl' it's an argument, whereas for 'build' it's
an option.

Also refactor the argument all around so that it's called
'filter' as opposed to 'version', and add a few comments about the logic.

This makes for a slightly quicker test cycle by running, for instance:

... -k Ubuntu -f 4.4.0-1089
... -k Debian -f 4.19.0-0
... -k Fedora -f 5.6.6-300.fc32