### PR TITLE
optimize download

### DIFF
--- a/probe_builder/kernel_crawler/debian.py
+++ b/probe_builder/kernel_crawler/debian.py
@@ -11,7 +11,7 @@ def repo_filter(dist):
 class DebianMirror(repo.Distro):
     def __init__(self):
         mirrors = [
-            deb.DebMirror('https://mirrors.edge.kernel.org/debian/', repo_filter),
+            deb.DebMirror('http://mirrors.edge.kernel.org/debian/', repo_filter),
             deb.DebMirror('http://security.debian.org/', repo_filter),
         ]
         super(DebianMirror, self).__init__(mirrors)

--- a/probe_builder/kernel_crawler/ubuntu.py
+++ b/probe_builder/kernel_crawler/ubuntu.py
@@ -5,7 +5,7 @@ from . import repo
 class UbuntuMirror(repo.Distro):
     def __init__(self):
         mirrors = [
-            deb.DebMirror('https://mirrors.edge.kernel.org/ubuntu/'),
+            deb.DebMirror('http://mirrors.edge.kernel.org/ubuntu/'),
             deb.DebMirror('http://security.ubuntu.com/ubuntu/'),
         ]
         super(UbuntuMirror, self).__init__(mirrors)


### PR DESCRIPTION
In order to handle incomplete downloads, the current implementation
will always try to append any remaining bytes to an already existing files.
But this means issuing at least one HTTP request per file, which might
slow down the process dramatically.
Instead, use temporary .part files and rename to the their filename
once complete -- this way we can assume that a file with the right name
is always complete and we can skip the download altogether.