### PR TITLE
Dedicated AmazonLinux2 builder

### DIFF
--- a/Dockerfile.amzn2-gcc7.3-bpf
+++ b/Dockerfile.amzn2-gcc7.3-bpf
@@ -1,0 +1,24 @@
+FROM amazonlinux:2
+
+RUN yum -y install \
+	wget \
+	git \
+	gcc \
+	gcc-c++ \
+	autoconf \
+	bison \
+	flex \
+	make \
+	cmake \
+	elfutils-devel \
+	findutils \
+	kmod \
+	clang7.0 \
+	llvm7.0 \
+	python-lxml && yum clean all
+
+ADD builder-entrypoint.sh /
+ENV CLANG clang-7
+ENV LLC llc-7.0
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]

--- a/Dockerfile.amzn2-gcc7.3-bpf
+++ b/Dockerfile.amzn2-gcc7.3-bpf
@@ -18,6 +18,8 @@ RUN yum -y install \
 	python-lxml && yum clean all
 
 ADD builder-entrypoint.sh /
+# Enforce usage of clang 7, as it's more battle tested than clang 11
+# which comes in the default clang package on AmazonLinux2
 ENV CLANG clang-7
 ENV LLC llc-7.0
 WORKDIR /build/probe

--- a/builder-entrypoint.sh
+++ b/builder-entrypoint.sh
@@ -10,6 +10,13 @@
 # PROBE_NAME
 # PROBE_VERSION
 
+# optional env vars
+# CLANG
+# LLC
+
+export CLANG=${CLANG:-clang}
+export LLC=${LLC:-llc}
+
 set -euo pipefail
 
 ARCH=$(uname -m)
@@ -55,9 +62,9 @@ build_kmod() {
 
 
 build_bpf() {
-	if ! type -p clang > /dev/null
+	if ! type -p $CLANG > /dev/null
 	then
-		echo "clang not available, not building eBPF probe $PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o"
+		echo "$CLANG not available, not building eBPF probe $PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o"
 	else
 		echo "Building eBPF probe $PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o"
 		make -C /build/probe/sysdig/driver/bpf clean all

--- a/probe_builder/builder/choose_builder.py
+++ b/probe_builder/builder/choose_builder.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 AUTOCONF_RE = re.compile('^#define CONFIG_GCC_VERSION ([0-9][0-9]?)([0-9][0-9])([0-9][0-9])$')
 LINUX_COMPILER_RE = re.compile('^#define LINUX_COMPILER "gcc version ([0-9.]+)')
 FEDORA_KERNEL_RE = re.compile(r'.*\.(fc[0-9]+)\..*Kernel Configuration$')
+AMAZONLINUX2_KERNEL_RE = re.compile(r'.*\.amzn2\..*Kernel Configuration$')
 
 
 def get_kernel_distro_tag(kernel_dir):
@@ -29,6 +30,9 @@ def get_kernel_distro_tag(kernel_dir):
                 if m:
                     distro_tag = m.group(1)
                     return distro_tag
+                m = AMAZONLINUX2_KERNEL_RE.match(line)
+                if m:
+                    return 'amzn2'
     except IOError:
         pass
 


### PR DESCRIPTION
AmazonLinux2 ships with gcc 7.3, which makes us choose
the builder image based on Fedora 27. That comes with clang 5,
which does build the eBPF probe successully but the probe
fails verification, e.g. with kernel 4.14.275-207.503.amzn2.

Create a dedicated AmazonLinux2 builder, with clang 7 (as it's
more battle tested than clang 11 which comes in the default
clang package on AmazonLinux2).