### PR TITLE
parallel builds: mount driver code readonly and run cmake for ebpf

### DIFF
--- a/builder-entrypoint.sh
+++ b/builder-entrypoint.sh
@@ -46,7 +46,7 @@ build_kmod() {
 	mkdir -p /build/sysdig
 	cd /build/sysdig
 
-	call_cmake /build/probe/sysdig
+	call_cmake /code/sysdig-rw
 	make driver
 	strip -g driver/$PROBE_NAME.ko
 
@@ -67,10 +67,16 @@ build_bpf() {
 		echo "$CLANG not available, not building eBPF probe $PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o"
 	else
 		echo "Building eBPF probe $PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o"
-		make -C /build/probe/sysdig/driver/bpf clean all
-		cp /build/probe/sysdig/driver/bpf/probe.o $OUTPUT/$PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o
+		mkdir -p /build/sysdig
+		cd /build/sysdig
+		call_cmake /code/sysdig-rw
+		make -C /code/sysdig-rw/driver/bpf clean all
+		cp /code/sysdig-rw/driver/bpf/probe.o $OUTPUT/$PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o
 	fi
 }
+
+rm -rf /code/sysdig-rw
+cp -rf /code/sysdig-ro /code/sysdig-rw
 
 case "${1:-}" in
 	bpf) build_bpf;;

--- a/probe_builder/builder/builder_image.py
+++ b/probe_builder/builder/builder_image.py
@@ -39,11 +39,12 @@ def build(workspace, dockerfile, dockerfile_tag):
 def run(workspace, probe, kernel_dir, kernel_release,
         config_hash, container_name, image_name, args):
     volumes = [
-        docker.DockerVolume(workspace.host_workspace(), '/build/probe', False),
-        docker.DockerVolume(workspace.host_dir(probe.sysdig_dir), '/build/probe/sysdig', False),
+        docker.DockerVolume(workspace.host_dir(probe.sysdig_dir), '/code/sysdig-ro', True),
+        docker.DockerVolume(workspace.host_workspace(), '/build/probe', True),
+        docker.DockerVolume(workspace.host_workspace() + "/output", '/output', False),
     ]
     env = [
-        docker.EnvVar('OUTPUT', '/build/probe/output'),
+        docker.EnvVar('OUTPUT', '/output'),
         docker.EnvVar('PROBE_NAME', probe.probe_name),
         docker.EnvVar('PROBE_VERSION', probe.probe_version),
         docker.EnvVar('PROBE_DEVICE_NAME', probe.probe_device_name),


### PR DESCRIPTION
this will be the preliminary step to parallel builds:

====
- part 1: mount code readonly
====
- part 2: fix handling of bpf probes when source is mounted readonly

the previous implementation, with the driver folder mounted in r/w,
was working through some side effects of building the kmod:
it would create files (e.g. driver_config.h) which would be
available to the subsequent invocation for eBPF.
Now that such folders are no longer shared through the host filesystem,
they would get the artifacts from whatever build was done on the host
prior to introducing the parallel builders.
The end result was that we would get probes built with the wrong
version information.

So fix this by having an explicit run of cmake on it for the
eBPF case, too.
Also, it would be a good idea to run the builder off a clean
git checkout for the driver.