### PR TITLE
PhotonOS generic kernel support

### DIFF
--- a/Dockerfile.photonos-gcc10.3-bpf
+++ b/Dockerfile.photonos-gcc10.3-bpf
@@ -1,0 +1,1 @@
+Dockerfile.centos-gcc10.3-bpf

--- a/Dockerfile.photonos-gcc7.3-bpf
+++ b/Dockerfile.photonos-gcc7.3-bpf
@@ -1,0 +1,1 @@
+Dockerfile.centos-gcc7.3-bpf

--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -84,6 +84,7 @@ CLI_DISTROS = {
     'Oracle7': CrawlDistro('oracle7', 'oracle', 'Oracle7'),
     'Oracle8': CrawlDistro('oracle8', 'oracle', 'Oracle8'),
     'Ubuntu': CrawlDistro('ubuntu', 'ubuntu', 'Ubuntu'),
+    'PhotonOS': CrawlDistro('photonos', 'photonos', 'PhotonOS'),
     'CustomCentOS': LocalDistro('custom-centos', 'centos'),
     'CustomDebian': LocalDistro('custom-debian', 'debian'),
     'CustomUbuntu': LocalDistro('custom-ubuntu', 'ubuntu'),

--- a/probe_builder/builder/choose_builder.py
+++ b/probe_builder/builder/choose_builder.py
@@ -96,7 +96,7 @@ def choose_gcc_dockerfile(builder_source, builder_distro, kernel_dir):
     kernel_gcc = get_kernel_gcc_version(kernel_dir)
     # We don't really care about the compiler patch levels, only the major/minor version
     kernel_gcc = Version(kernel_gcc)
-    logger.debug('found gcc version {}'.format(kernel_gcc))
+    logger.debug('found kernel gcc version {}'.format(kernel_gcc))
 
     # Choose the right gcc version from the ones we have available (as Docker images)
     # - if we have the exact minor version, use it

--- a/probe_builder/builder/choose_builder.py
+++ b/probe_builder/builder/choose_builder.py
@@ -96,6 +96,7 @@ def choose_gcc_dockerfile(builder_source, builder_distro, kernel_dir):
     kernel_gcc = get_kernel_gcc_version(kernel_dir)
     # We don't really care about the compiler patch levels, only the major/minor version
     kernel_gcc = Version(kernel_gcc)
+    logger.debug('found gcc version {}'.format(kernel_gcc))
 
     # Choose the right gcc version from the ones we have available (as Docker images)
     # - if we have the exact minor version, use it

--- a/probe_builder/builder/distro/__init__.py
+++ b/probe_builder/builder/distro/__init__.py
@@ -3,6 +3,7 @@ from .centos import CentosBuilder
 from .debian import DebianBuilder
 from .flatcar import FlatcarBuilder
 from .ubuntu import UbuntuBuilder
+from .photonos import PhotonosBuilder
 
 
 class Distro(namedtuple('Distro', 'distro builder_distro')):
@@ -19,4 +20,5 @@ DISTRO_BUILDERS = {
     'flatcar': FlatcarBuilder,
     'ubuntu': UbuntuBuilder,
     'oracle': CentosBuilder,
+    'photonos': PhotonosBuilder,
 }

--- a/probe_builder/builder/distro/photonos.py
+++ b/probe_builder/builder/distro/photonos.py
@@ -1,0 +1,30 @@
+from probe_builder.builder import toolkit
+from .centos import CentosBuilder
+
+
+class PhotonosBuilder(CentosBuilder):
+    @staticmethod
+    def strip_release(release):
+        # remove trailing arch, if any
+        if release.endswith(".x86_64"):
+            return release[: -len(".x86_64")]
+        return release
+
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, filter=""):
+        # call the parent's method
+        orig = super().crawl(
+            workspace=workspace,
+            distro=distro,
+            crawler_distro=crawler_distro,
+            download_config=download_config,
+            filter=filter,
+        )
+        # make up a new list with stripped release version
+        renamed = {}
+        for release, urls in orig.items():
+            renamed[self.strip_release(release)] = urls
+        return renamed
+
+    def get_kernel_dir(self, workspace, release, target):
+        # Photon OS is rpm based but the kernel dir structure is the debian one ¯\_(ツ)_/¯
+        return workspace.subdir(target, "usr/src/linux-headers-{}".format(release))

--- a/probe_builder/kernel_crawler/photon_os.py
+++ b/probe_builder/kernel_crawler/photon_os.py
@@ -5,7 +5,18 @@ from . import repo
 class PhotonOsRepository(rpm.RpmRepository):
     @classmethod
     def kernel_package_query(cls):
-        return '''((name = 'linux' OR name LIKE 'linux-%devel%') AND name NOT LIKE '%esx%')'''
+        # We exclude `esx` kernels because they don't support CONFIG_TRACEPOINTS,
+        # see https://github.com/vmware/photon/issues/1223.
+        # We also exclude all the other variants for now (plus Linux-PAM-devel).
+        return '''(
+            (name = 'linux' OR name LIKE 'linux-%devel%')
+            AND name NOT LIKE '%-PAM-%'
+            AND name NOT LIKE '%-esx-%'
+            AND name NOT LIKE '%-rt-%'
+            AND name NOT LIKE '%-secure-%'
+            AND name NOT LIKE '%-aws-%'
+        )
+        '''
 
 
 class PhotonOsMirror(repo.Distro):


### PR DESCRIPTION
Rework of #3. I left that one in place because it might have some useful info for the other kernel variants.