### PR TITLE
Introduce the possibility to build a single kernel-probe for Fedora

### DIFF
--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -90,6 +90,7 @@ CLI_DISTROS = {
     'CustomDebian': LocalDistro('custom-debian', 'debian'),
     'CustomUbuntu': LocalDistro('custom-ubuntu', 'ubuntu'),
     'CustomFlatcar': LocalDistro('custom-flatcar', 'flatcar'),
+    'CustomFedora': LocalDistro('custom-fedora', 'centos'),
 }
 
 

--- a/probe_builder/builder/distro/__init__.py
+++ b/probe_builder/builder/distro/__init__.py
@@ -17,6 +17,7 @@ class Distro(namedtuple('Distro', 'distro builder_distro')):
 DISTRO_BUILDERS = {
     'centos': CentosBuilder,
     'debian': DebianBuilder,
+    'fedora': CentosBuilder,
     'flatcar': FlatcarBuilder,
     'ubuntu': UbuntuBuilder,
     'oracle': CentosBuilder,


### PR DESCRIPTION
Added the possibility to specify `-k CustomFedora` for building a single probe for this distro