### PR TITLE
add support for Fedora 36

### DIFF
--- a/Dockerfile.centos-gcc12.1-bpf
+++ b/Dockerfile.centos-gcc12.1-bpf
@@ -1,0 +1,22 @@
+FROM fedora:36
+
+RUN yum -y install \
+	wget \
+	git \
+	gcc \
+	gcc-c++ \
+	autoconf \
+	bison \
+	flex \
+	make \
+	cmake \
+	elfutils-devel \
+	findutils \
+	kmod \
+	clang \
+	llvm \
+	python-lxml && yum clean all
+
+ADD builder-entrypoint.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]


### PR DESCRIPTION
Fedora 36 uses gcc 12.1.1 20220507.
Without a dedicated builder, we'd end up with gcc 11.2.1 which
doesn't support -mharden-sls=all.

So just invite Fedora 36 to the party -- the more the merrier.