### PR TITLE
Add gcc10 to amazn2

### DIFF
--- a/Dockerfile.amzn2-gcc7.3-bpf
+++ b/Dockerfile.amzn2-gcc7.3-bpf
@@ -5,6 +5,7 @@ RUN yum -y install \
 	git \
 	gcc \
 	gcc-c++ \
+	gcc10 \
 	autoconf \
 	bison \
 	flex \


### PR DESCRIPTION
Trying to compile probes for the most recent amazn2 kernels results
in the following message:

make[8]: gcc10-gcc: Command not found
/bin/sh: gcc10-gcc: command not found

So it looks like they get compiled using gcc 10 which is packaged as
a dedicated gcc10 package.
Just add it to the amzn2 builder, there's no need to create a separate
builder.

bash-4.2# gcc --version
gcc (GCC) 7.3.1 20180712 (Red Hat 7.3.1-15)
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

bash-4.2# gcc10-gcc --version
gcc10-gcc (GCC) 10.3.1 20210422 (Red Hat 10.3.1-1)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.