### PR TITLE
fix(toolkit): use bsdtar instead of rpm2cpio

### DIFF
--- a/toolkit-entrypoint.sh
+++ b/toolkit-entrypoint.sh
@@ -38,8 +38,11 @@ unpack_rpm()
 {
 	KERNEL_PACKAGE="$1"
 	OUTPUT_DIR="$2"
-
-	rpm2cpio "$KERNEL_PACKAGE" | (cd "$OUTPUT_DIR" && cpio -idm)
+	# This "rpm2cpio | cpio pipeline" seems to fail under obscure circumstances
+	# rpm2cpio "$KERNEL_PACKAGE" | (cd "$OUTPUT_DIR" && cpio -idm)
+	# since alpine ships a bsdtar which seems perfectly capable (in and of itself)
+	# of extracting the files we need from an .rpm file, use that instead
+	bsdtar xvf "$KERNEL_PACKAGE" -C "$OUTPUT_DIR"
 }
 
 case "$1" in


### PR DESCRIPTION
Under some mysterious circumstances, the probe builder will fail to extract rpm files with the following error:

bsdtar: Write error
bsdtar: Error exit delayed from previous errors.

The reasons are not clear at all since the issue only popped up in the past week or so (2022-11-04) and only on certain machines.
When the environment is subject to this problem, you can reproduce it by the following sequence:

docker build -t sysdig-probe-builder .
[[ -f test.rpm ]] || wget -O test.rpm http://amazonlinux.us-east-1.amazonaws.com/blobstore/78fc937cb9b95b5f033ab23f538e3fee3a1855ff845f23f1039488b3d81c0fb2/kernel-5.4.219-126.411.amzn2.x86_64.rpm docker run -it --rm -v $PWD/test.rpm:/test.rpm --entrypoint=/bin/sh sysdig-probe-builder -c 'rpm2cpio /test.rpm | (cd /tmp && cpio -idm)'

As a matter of fact, since alpine ships a bsdtar which seems perfectly capable (in and of itself) of extracting the files we need from an .rpm file, use that instead