### PR TITLE
Dockerfiles: pin alpine version to be used as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.16
 
 RUN apk add \
     bash \

--- a/Dockerfile.toolkit
+++ b/Dockerfile.toolkit
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.16
 
 RUN apk add rpm2cpio multipath-tools sfdisk jq
 ADD toolkit-entrypoint.sh /toolkit-entrypoint.sh


### PR DESCRIPTION
Recent updates of alpine seem to have changed a few things. Pin to a version which is known to work to prevent unexpected changes.