### PR TITLE
add builder with gcc12.2 for ubuntu kinetic kernels

### DIFF
--- a/Dockerfile.ubuntu-gcc12.2-bpf
+++ b/Dockerfile.ubuntu-gcc12.2-bpf
@@ -1,0 +1,21 @@
+FROM ubuntu:kinetic
+
+RUN echo 'deb http://archive.ubuntu.com/ubuntu/ kinetic-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/ubuntu-proposed.list && \
+	apt-get update && \
+	apt-get -y --no-install-recommends install \
+		cmake \
+		g++ \
+		git \
+		kmod \
+		libc6-dev \
+		libelf-dev \
+		make \
+		pkg-config \
+		clang \
+		llvm \
+		&& apt-get clean
+
+ADD builder-entrypoint.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]
+


### PR DESCRIPTION
kernels compiled with gcc12.x (namely the ones shipped on kinetic 22.10) will fail to compile with the current builder:

    The kernel was built by: x86_64-linux-gnu-gcc-12 (Ubuntu 12.1.0-2ubuntu1~22.04) 12.1.0
    You are using:           gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0
  gcc: error: unrecognized command-line option '-ftrivial-auto-var-init=zero'

add a new image based on ubuntu 22.10 (kinetic) which sports gcc 12.2 by default.