### PR TITLE
add support for distro release filtering

### DIFF
--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -61,8 +61,8 @@ class CrawlDistro(object):
         self.distro_builder = self.distro_obj.builder()
         self.crawler_distro = crawler_distro
 
-    def get_kernels(self, workspace, _packages, download_config, filter):
-        return self.distro_builder.crawl(workspace, self.distro_obj, self.crawler_distro, download_config, filter)
+    def get_kernels(self, workspace, _packages, download_config, distro_filter, kernel_filter):
+        return self.distro_builder.crawl(workspace, self.distro_obj, self.crawler_distro, download_config, distro_filter, kernel_filter)
 
 class LocalDistro(object):
 
@@ -70,7 +70,7 @@ class LocalDistro(object):
         self.distro_obj = Distro(distro, builder_distro)
         self.distro_builder = self.distro_obj.builder()
 
-    def get_kernels(self, _workspace, packages, _download_config, filter):
+    def get_kernels(self, _workspace, packages, _download_config, _distro_filter, _kernel_filter):
         return self.distro_builder.batch_packages(packages)
 
 
@@ -109,7 +109,8 @@ def cli(debug):
 @click.option('-d', '--download-concurrency', type=click.INT, default=1)
 @click.option('-j', '--jobs', type=click.INT, default=len(os.sched_getaffinity(0)))
 @click.option('-k', '--kernel-type', type=click.Choice(sorted(CLI_DISTROS.keys())))
-@click.option('-f', '--filter', default='')
+@click.option('-R', '--distro-filter', default='')
+@click.option('-f', '--kernel-filter', default='')
 @click.option('-p', '--probe-name')
 @click.option('-r', '--retries', type=click.INT, default=1)
 @click.option('-s', '--source-dir')
@@ -117,7 +118,8 @@ def cli(debug):
 @click.option('-v', '--probe-version')
 @click.argument('package', nargs=-1)
 def build(builder_image_prefix,
-          download_concurrency, jobs, kernel_type, filter, probe_name, retries,
+          download_concurrency, jobs, kernel_type, distro_filter,
+          kernel_filter, probe_name, retries,
           source_dir, download_timeout, probe_version, package):
     workspace_dir = os.getcwd()
     builder_source = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -130,7 +132,7 @@ def build(builder_image_prefix,
     distro = distro_obj.distro_obj
     download_config = DownloadConfig(download_concurrency, download_timeout, retries, None)
 
-    kernels = distro_obj.get_kernels(workspace, package, download_config, filter)
+    kernels = distro_obj.get_kernels(workspace, package, download_config, distro_filter, kernel_filter)
     kernel_dirs = distro_builder.unpack_kernels(workspace, distro.distro, kernels)
 
     with ThreadPoolExecutor(max_workers=jobs) as executor:
@@ -190,9 +192,10 @@ def build(builder_image_prefix,
 
 @click.command()
 @click.argument('distro', type=click.Choice(sorted(DISTROS.keys())))
+@click.argument('distro_filter', required=False, default='')
 @click.argument('version', required=False, default='')
-def crawl(distro, version=''):
-    kernels = crawl_kernels(distro, version)
+def crawl(distro, distro_filter='', version=''):
+    kernels = crawl_kernels(distro, distro_filter, version)
     for release, packages in kernels.items():
         print('=== {} ==='.format(release))
         for pkg in packages:

--- a/probe_builder/builder/distro/base_builder.py
+++ b/probe_builder/builder/distro/base_builder.py
@@ -147,8 +147,8 @@ class DistroBuilder(object):
     def batch_packages(self, kernel_files):
         raise NotImplementedError
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None, filter=''):
-        kernels = crawl_kernels(crawler_distro, filter)
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, distro_filter='', kernel_filter=''):
+        kernels = crawl_kernels(crawler_distro, distro_filter, kernel_filter)
         try:
             os.makedirs(workspace.subdir(distro.distro))
         except OSError as exc:

--- a/probe_builder/builder/distro/base_builder.py
+++ b/probe_builder/builder/distro/base_builder.py
@@ -9,6 +9,7 @@ import click
 from probe_builder import docker
 from probe_builder.builder import builder_image, choose_builder
 from probe_builder.kernel_crawler import crawl_kernels
+from probe_builder.kernel_crawler.repo import EMPTY_FILTER
 from probe_builder.kernel_crawler.download import download_batch
 from probe_builder.py23 import make_bytes, make_string
 
@@ -147,8 +148,8 @@ class DistroBuilder(object):
     def batch_packages(self, kernel_files):
         raise NotImplementedError
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None, distro_filter='', kernel_filter=''):
-        kernels = crawl_kernels(crawler_distro, distro_filter, kernel_filter)
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, crawler_filter=EMPTY_FILTER):
+        kernels = crawl_kernels(crawler_distro, crawler_filter)
         try:
             os.makedirs(workspace.subdir(distro.distro))
         except OSError as exc:

--- a/probe_builder/builder/distro/debian.py
+++ b/probe_builder/builder/distro/debian.py
@@ -8,6 +8,7 @@ import click
 
 from probe_builder.builder import toolkit
 from probe_builder.builder.distro.base_builder import DistroBuilder
+from probe_builder.kernel_crawler.repo import EMPTY_FILTER
 
 logger = logging.getLogger(__name__)
 pp = pprint.PrettyPrinter(depth=4)
@@ -17,14 +18,14 @@ class DebianBuilder(DistroBuilder):
     KBUILD_PACKAGE_RE = re.compile(r'linux-kbuild-(?P<major>[0-9]\.[0-9]+)_')
 
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None, distro_filter='', kernel_filter=''):
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, crawler_filter=EMPTY_FILTER):
         # for debian, we essentially want to discard the classification work performed by the crawler,
         # and batch packages together
 
         # call the parent's method
         crawled_dict = super().crawl(workspace=workspace, distro=distro,
             crawler_distro=crawler_distro, download_config=download_config,
-            distro_filter=distro_filter, kernel_filter=kernel_filter)
+            crawler_filter=crawler_filter)
 
         # flatten that dictionary into a single list, retaining ONLY package urls and discarding the release altogether
         flattened_packages = [pkg for pkgs in crawled_dict.values() for pkg in pkgs]

--- a/probe_builder/builder/distro/debian.py
+++ b/probe_builder/builder/distro/debian.py
@@ -17,12 +17,14 @@ class DebianBuilder(DistroBuilder):
     KBUILD_PACKAGE_RE = re.compile(r'linux-kbuild-(?P<major>[0-9]\.[0-9]+)_')
 
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None, filter=''):
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, distro_filter='', kernel_filter=''):
         # for debian, we essentially want to discard the classification work performed by the crawler,
         # and batch packages together
 
         # call the parent's method
-        crawled_dict = super().crawl(workspace=workspace, distro=distro, crawler_distro=crawler_distro, download_config=download_config, filter=filter)
+        crawled_dict = super().crawl(workspace=workspace, distro=distro,
+            crawler_distro=crawler_distro, download_config=download_config,
+            distro_filter=distro_filter, kernel_filter=kernel_filter)
 
         # flatten that dictionary into a single list, retaining ONLY package urls and discarding the release altogether
         flattened_packages = [pkg for pkgs in crawled_dict.values() for pkg in pkgs]

--- a/probe_builder/builder/distro/flatcar.py
+++ b/probe_builder/builder/distro/flatcar.py
@@ -69,8 +69,8 @@ class FlatcarBuilder(DistroBuilder):
         else:
             logger.info("Build for {} probe {}-{} ({}) successful".format(label, coreos_kernel_release, config_hash, release))
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None, filter=''):
-        kernels = crawl_kernels(crawler_distro, filter)
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, distro_filter='', kernel_filter=''):
+        kernels = crawl_kernels(crawler_distro, distro_filter, kernel_filter)
         try:
             os.makedirs(workspace.subdir(distro.distro))
         except OSError as exc:

--- a/probe_builder/builder/distro/flatcar.py
+++ b/probe_builder/builder/distro/flatcar.py
@@ -10,6 +10,7 @@ from .base_builder import DistroBuilder, to_s
 from .. import toolkit, builder_image
 from ... import crawl_kernels, docker
 from ...kernel_crawler.download import download_file
+from ...kernel_crawler.repo import EMPTY_FILTER
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +70,8 @@ class FlatcarBuilder(DistroBuilder):
         else:
             logger.info("Build for {} probe {}-{} ({}) successful".format(label, coreos_kernel_release, config_hash, release))
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None, distro_filter='', kernel_filter=''):
-        kernels = crawl_kernels(crawler_distro, distro_filter, kernel_filter)
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, crawler_filter=EMPTY_FILTER):
+        kernels = crawl_kernels(crawler_distro, crawler_filter=crawler_filter)
         try:
             os.makedirs(workspace.subdir(distro.distro))
         except OSError as exc:

--- a/probe_builder/builder/distro/photonos.py
+++ b/probe_builder/builder/distro/photonos.py
@@ -1,4 +1,5 @@
 from probe_builder.builder import toolkit
+from probe_builder.kernel_crawler.repo import EMPTY_FILTER
 from .centos import CentosBuilder
 
 
@@ -10,15 +11,14 @@ class PhotonosBuilder(CentosBuilder):
             return release[: -len(".x86_64")]
         return release
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None, distro_filter="", kernel_filter=""):
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, crawler_filter=EMPTY_FILTER):
         # call the parent's method
         orig = super().crawl(
             workspace=workspace,
             distro=distro,
             crawler_distro=crawler_distro,
             download_config=download_config,
-            distro_filter=distro_filter,
-            kernel_filter=kernel_filter,
+            crawler_filter=crawler_filter,
         )
         # make up a new list with stripped release version
         renamed = {}

--- a/probe_builder/builder/distro/photonos.py
+++ b/probe_builder/builder/distro/photonos.py
@@ -10,14 +10,15 @@ class PhotonosBuilder(CentosBuilder):
             return release[: -len(".x86_64")]
         return release
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None, filter=""):
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, distro_filter="", kernel_filter=""):
         # call the parent's method
         orig = super().crawl(
             workspace=workspace,
             distro=distro,
             crawler_distro=crawler_distro,
             download_config=download_config,
-            filter=filter,
+            distro_filter=distro_filter,
+            kernel_filter=kernel_filter,
         )
         # make up a new list with stripped release version
         renamed = {}

--- a/probe_builder/builder/distro/ubuntu.py
+++ b/probe_builder/builder/distro/ubuntu.py
@@ -7,6 +7,7 @@ import click
 
 from probe_builder.builder import toolkit
 from .base_builder import DistroBuilder
+from probe_builder.kernel_crawler.repo import EMPTY_FILTER
 
 logger = logging.getLogger(__name__)
 pp = pprint.PrettyPrinter(depth=4)
@@ -15,8 +16,8 @@ class UbuntuBuilder(DistroBuilder):
     KERNEL_VERSION_RE = re.compile(r'(?P<version>[0-9]\.[0-9]+\.[0-9]+-[0-9]+)\.(?P<update>[0-9][^_]*)')
     KERNEL_RELEASE_RE = re.compile(r'(?P<release>[0-9]\.[0-9]+\.[0-9]+-[0-9]+-[a-z0-9-]+)')
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None, distro_filter='', kernel_filter=''):
-        crawled_dict = super().crawl(workspace=workspace, distro=distro, crawler_distro=crawler_distro, download_config=download_config, distro_filter=distro_filter, kernel_filter=kernel_filter)
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, crawler_filter=EMPTY_FILTER):
+        crawled_dict = super().crawl(workspace=workspace, distro=distro, crawler_distro=crawler_distro, download_config=download_config, crawler_filter=crawler_filter)
         kernels = []
         # batch packages according to package version, e.g. '5.15.0-1001/1' as returned by the crawler
         # (which is the package version of the main 'linux-headers-5.15.0-1001-gke_5.15.0-1001.1_amd64.deb')

--- a/probe_builder/builder/distro/ubuntu.py
+++ b/probe_builder/builder/distro/ubuntu.py
@@ -15,8 +15,8 @@ class UbuntuBuilder(DistroBuilder):
     KERNEL_VERSION_RE = re.compile(r'(?P<version>[0-9]\.[0-9]+\.[0-9]+-[0-9]+)\.(?P<update>[0-9][^_]*)')
     KERNEL_RELEASE_RE = re.compile(r'(?P<release>[0-9]\.[0-9]+\.[0-9]+-[0-9]+-[a-z0-9-]+)')
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None, filter=''):
-        crawled_dict = super().crawl(workspace=workspace, distro=distro, crawler_distro=crawler_distro, download_config=download_config, filter=filter)
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, distro_filter='', kernel_filter=''):
+        crawled_dict = super().crawl(workspace=workspace, distro=distro, crawler_distro=crawler_distro, download_config=download_config, distro_filter=distro_filter, kernel_filter=kernel_filter)
         kernels = []
         # batch packages according to package version, e.g. '5.15.0-1001/1' as returned by the crawler
         # (which is the package version of the main 'linux-headers-5.15.0-1001-gke_5.15.0-1001.1_amd64.deb')

--- a/probe_builder/kernel_crawler/__init__.py
+++ b/probe_builder/kernel_crawler/__init__.py
@@ -32,10 +32,6 @@ DISTROS = {
     'Flatcar': FlatcarMirror,
 }
 
-
-def crawl_kernels(distro, distro_filter='', kernel_filter=''):
-    dist = DISTROS[distro]()
-    dist.set_distro_filter(distro_filter)
-    pt = dist.get_package_tree(kernel_filter)
-    dist.set_distro_filter('')
-    return pt
+def crawl_kernels(distro, crawler_filter):
+    dist = DISTROS[distro]
+    return dist().get_package_tree(crawler_filter)

--- a/probe_builder/kernel_crawler/__init__.py
+++ b/probe_builder/kernel_crawler/__init__.py
@@ -33,7 +33,9 @@ DISTROS = {
 }
 
 
-def crawl_kernels(distro, version=''):
-    dist = DISTROS[distro]
-
-    return dist().get_package_tree(version)
+def crawl_kernels(distro, distro_filter='', kernel_filter=''):
+    dist = DISTROS[distro]()
+    dist.set_distro_filter(distro_filter)
+    pt = dist.get_package_tree(kernel_filter)
+    dist.set_distro_filter('')
+    return pt

--- a/probe_builder/kernel_crawler/amazonlinux.py
+++ b/probe_builder/kernel_crawler/amazonlinux.py
@@ -33,7 +33,7 @@ class AmazonLinux1Mirror(repo.Distro):
     def __init__(self):
         super(AmazonLinux1Mirror, self).__init__([])
 
-    def list_repos(self):
+    def list_repos(self, crawler_filter):
         repo_urls = set()
         with click.progressbar(
                 self.AL1_REPOS, label='Checking repositories', file=sys.stderr, item_show_func=repo.to_s) as repos:
@@ -53,7 +53,7 @@ class AmazonLinux2Mirror(repo.Distro):
     def __init__(self):
         super(AmazonLinux2Mirror, self).__init__([])
 
-    def list_repos(self):
+    def list_repos(self, crawler_filter):
         repo_urls = set()
         with click.progressbar(
                 self.AL2_REPOS, label='Checking repositories', file=sys.stderr, item_show_func=repo.to_s) as repos:
@@ -88,7 +88,7 @@ class AmazonLinux2022Mirror(repo.Distro):
     def __init__(self):
         super(AmazonLinux2022Mirror, self).__init__([])
 
-    def list_repos(self):
+    def list_repos(self, crawler_filter):
         repos = []
         for base_url in self.AL202X_BASE_URLS:
             repos.extend(self.list_repos_for_url(base_url=base_url))

--- a/probe_builder/kernel_crawler/deb.py
+++ b/probe_builder/kernel_crawler/deb.py
@@ -220,9 +220,9 @@ class DebRepository(repo.Repository):
         logger.debug("after pruning, deps=\n{}".format(pp.pformat(deps)))
         return deps
 
-    def get_package_tree(self, filter=''):
+    def get_package_tree(self, kernel_filter=''):
         packages = self.get_raw_package_db()
-        package_list = self.get_package_list(packages, filter)
+        package_list = self.get_package_list(packages, kernel_filter)
         return self.build_package_tree(packages, package_list)
 
 
@@ -267,8 +267,10 @@ class DebMirror(repo.Mirror):
                  and not dist.startswith('?')
                  and not dist.startswith('http')
                  and self.repo_filter(dist)
+                 and dist.startswith(self.distro_filter)
                  ]
 
+        logger.info("Dists found under {}, filtered by '{}': {}".format(dists_url, self.distro_filter, dists))
         repos = {}
         with click.progressbar(
                 dists, label='Scanning {}'.format(self.base_url), file=sys.stderr, item_show_func=repo.to_s) as dists:

--- a/probe_builder/kernel_crawler/deb.py
+++ b/probe_builder/kernel_crawler/deb.py
@@ -12,6 +12,7 @@ import requests
 from lxml import html
 
 from . import repo
+from probe_builder.kernel_crawler.repo import EMPTY_FILTER
 from probe_builder.kernel_crawler.download import get_first_of, get_url
 from probe_builder.py23 import make_bytes, make_string
 import pprint
@@ -220,9 +221,9 @@ class DebRepository(repo.Repository):
         logger.debug("after pruning, deps=\n{}".format(pp.pformat(deps)))
         return deps
 
-    def get_package_tree(self, kernel_filter=''):
+    def get_package_tree(self, crawler_filter=EMPTY_FILTER):
         packages = self.get_raw_package_db()
-        package_list = self.get_package_list(packages, kernel_filter)
+        package_list = self.get_package_list(packages, crawler_filter.kernel_filter)
         return self.build_package_tree(packages, package_list)
 
 
@@ -255,7 +256,7 @@ class DebMirror(repo.Mirror):
             repos[url] = DebRepository(self.base_url, url)
         return repos
 
-    def list_repos(self):
+    def list_repos(self, crawler_filter):
         dists_url = self.base_url + 'dists/'
         dists = requests.get(dists_url)
         dists.raise_for_status()
@@ -267,10 +268,10 @@ class DebMirror(repo.Mirror):
                  and not dist.startswith('?')
                  and not dist.startswith('http')
                  and self.repo_filter(dist)
-                 and dist.startswith(self.distro_filter)
+                 and dist.startswith(crawler_filter.distro_filter)
                  ]
 
-        logger.info("Dists found under {}, filtered by '{}': {}".format(dists_url, self.distro_filter, dists))
+        logger.info("Dists found under {}, filtered by '{}': {}".format(dists_url, crawler_filter.distro_filter, dists))
         repos = {}
         with click.progressbar(
                 dists, label='Scanning {}'.format(self.base_url), file=sys.stderr, item_show_func=repo.to_s) as dists:

--- a/probe_builder/kernel_crawler/debian.py
+++ b/probe_builder/kernel_crawler/debian.py
@@ -20,7 +20,7 @@ class DebianMirror(repo.Distro):
     # can be resolved (i.e. build_package_tree) across multiple repositories.
     # This is namely required for the linux-kbuild package, which is typically
     # hosted on a different repository compared to the kernel packages
-    def get_package_tree(self, version=''):
+    def get_package_tree(self, kernel_filter=''):
         all_packages = {}
         all_kernel_packages = []
         packages = {}
@@ -29,7 +29,7 @@ class DebianMirror(repo.Distro):
             for repository in repos:
                 repo_packages = repository.get_raw_package_db()
                 all_packages.update(repo_packages)
-                kernel_packages = repository.get_package_list(repo_packages, version)
+                kernel_packages = repository.get_package_list(repo_packages, kernel_filter)
                 all_kernel_packages.extend(kernel_packages)
 
         for release, dependencies in deb.DebRepository.build_package_tree(all_packages, all_kernel_packages).items():

--- a/probe_builder/kernel_crawler/debian.py
+++ b/probe_builder/kernel_crawler/debian.py
@@ -20,16 +20,16 @@ class DebianMirror(repo.Distro):
     # can be resolved (i.e. build_package_tree) across multiple repositories.
     # This is namely required for the linux-kbuild package, which is typically
     # hosted on a different repository compared to the kernel packages
-    def get_package_tree(self, kernel_filter=''):
+    def get_package_tree(self, crawler_filter):
         all_packages = {}
         all_kernel_packages = []
         packages = {}
-        repos = self.list_repos()
+        repos = self.list_repos(crawler_filter)
         with click.progressbar(repos, label='Listing packages', file=sys.stderr, item_show_func=repo.to_s) as repos:
             for repository in repos:
                 repo_packages = repository.get_raw_package_db()
                 all_packages.update(repo_packages)
-                kernel_packages = repository.get_package_list(repo_packages, kernel_filter)
+                kernel_packages = repository.get_package_list(repo_packages, crawler_filter.kernel_filter)
                 all_kernel_packages.extend(kernel_packages)
 
         for release, dependencies in deb.DebRepository.build_package_tree(all_packages, all_kernel_packages).items():

--- a/probe_builder/kernel_crawler/flatcar.py
+++ b/probe_builder/kernel_crawler/flatcar.py
@@ -10,7 +10,7 @@ class FlatcarRepository(Repository):
     def __init__(self, base_url):
         self.base_url = base_url
 
-    def get_package_tree(self, version=''):
+    def get_package_tree(self, kernel_filter=''):
         release = os.path.basename(self.base_url.rstrip('/'))
         if version not in release:
             return {}

--- a/probe_builder/kernel_crawler/flatcar.py
+++ b/probe_builder/kernel_crawler/flatcar.py
@@ -10,9 +10,9 @@ class FlatcarRepository(Repository):
     def __init__(self, base_url):
         self.base_url = base_url
 
-    def get_package_tree(self, kernel_filter=''):
+    def get_package_tree(self, crawler_filter):
         release = os.path.basename(self.base_url.rstrip('/'))
-        if version not in release:
+        if crawler_filter.kernel_filter not in release:
             return {}
         dev_container = os.path.join(self.base_url, 'flatcar_developer_container.bin.bz2')
         return {release: [dev_container]}

--- a/probe_builder/kernel_crawler/flatcar.py
+++ b/probe_builder/kernel_crawler/flatcar.py
@@ -41,7 +41,7 @@ class FlatcarMirror(Distro):
                 and '-' not in dist
                 ]
 
-    def list_repos(self):
+    def list_repos(self, crawler_filter):
         repos = []
         for repo in self.mirrors:
             repos.extend(self.scan_repo(repo))

--- a/probe_builder/kernel_crawler/oracle.py
+++ b/probe_builder/kernel_crawler/oracle.py
@@ -21,7 +21,7 @@ class Oracle6Mirror(repo.Distro):
     def __init__(self):
         super(Oracle6Mirror, self).__init__([])
 
-    def list_repos(self):
+    def list_repos(self, crawler_filter):
         return [OracleRepository(url) for url in self.OL6_REPOS]
 
 
@@ -38,7 +38,7 @@ class Oracle7Mirror(repo.Distro):
     def __init__(self):
         super(Oracle7Mirror, self).__init__([])
 
-    def list_repos(self):
+    def list_repos(self, crawler_filter):
         return [OracleRepository(url) for url in self.OL7_REPOS]
 
 
@@ -51,7 +51,7 @@ class Oracle8Mirror(repo.Distro):
     def __init__(self):
         super(Oracle8Mirror, self).__init__([])
 
-    def list_repos(self):
+    def list_repos(self, crawler_filter):
         return [OracleRepository(url) for url in self.OL8_REPOS]
 
 
@@ -65,5 +65,5 @@ class Oracle9Mirror(repo.Distro):
     def __init__(self):
         super(Oracle9Mirror, self).__init__([])
 
-    def list_repos(self):
+    def list_repos(self, crawler_filter):
         return [OracleRepository(url) for url in self.OL9_REPOS]

--- a/probe_builder/kernel_crawler/photon_os.py
+++ b/probe_builder/kernel_crawler/photon_os.py
@@ -31,7 +31,7 @@ class PhotonOsMirror(repo.Distro):
     def __init__(self):
         super(PhotonOsMirror, self).__init__([])
 
-    def list_repos(self):
+    def list_repos(self, crawler_filter):
         return [
             PhotonOsRepository('https://packages.vmware.com/photon/{v}/photon{r}_{v}_x86_64/'.format(
                 v=version, r=repo_tag))

--- a/probe_builder/kernel_crawler/repo.py
+++ b/probe_builder/kernel_crawler/repo.py
@@ -1,13 +1,11 @@
 from __future__ import print_function
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+from collections import namedtuple
 import click
 import sys
 
-class CrawlerFilter(object):
-    def __init__(self, distro_filter='', kernel_filter=''):
-        self.distro_filter = distro_filter
-        self.kernel_filter = kernel_filter
+CrawlerFilter = namedtuple("CrawlerFilter", ["distro_filter", "kernel_filter"], defaults=["",""])
 
 EMPTY_FILTER=CrawlerFilter()
 

--- a/probe_builder/kernel_crawler/repo.py
+++ b/probe_builder/kernel_crawler/repo.py
@@ -6,7 +6,7 @@ import sys
 
 
 class Repository(object):
-    def get_package_tree(self, version=''):
+    def get_package_tree(self, kernel_filter=''):
         raise NotImplementedError
 
     def __str__(self):
@@ -20,15 +20,23 @@ def to_s(s):
 
 
 class Mirror(object):
+
+    distro_filter=''
     def list_repos(self):
         raise NotImplementedError
 
-    def get_package_tree(self, version=''):
+    def __init__(self):
+        self.distro_filter = ''
+
+    def set_distro_filter(self, distro_filter):
+        self.distro_filter=distro_filter
+
+    def get_package_tree(self, kernel_filter=''):
         packages = {}
         repos = self.list_repos()
         with click.progressbar(length=len(repos), label='Listing packages', file=sys.stderr, item_show_func=to_s) as pbar:
             with ThreadPoolExecutor(max_workers=8) as executor:
-                futures = { executor.submit(repo.get_package_tree, version): str(repo) for repo in repos }
+                futures = { executor.submit(repo.get_package_tree, kernel_filter): str(repo) for repo in repos }
                 for future in as_completed(futures):
                     repo = futures[future]
                     for release, dependencies in future.result().items():
@@ -39,12 +47,16 @@ class Mirror(object):
 
 class Distro(Mirror):
     def __init__(self, mirrors):
+        super().__init__()
         self.mirrors = mirrors
+
 
     def list_repos(self):
         repos = []
         with click.progressbar(
                 self.mirrors, label='Checking repositories', file=sys.stderr, item_show_func=to_s) as mirrors:
             for mirror in mirrors:
+                mirror.set_distro_filter(self.distro_filter)
                 repos.extend(mirror.list_repos())
+                mirror.set_distro_filter('')
         return repos

--- a/probe_builder/kernel_crawler/rpm.py
+++ b/probe_builder/kernel_crawler/rpm.py
@@ -73,7 +73,7 @@ class RpmRepository(repo.Repository):
         pkglist_url = self.get_loc_by_xpath(repomd, '//repo:repomd/repo:data[@type="primary_db"]/repo:location/@href')
         return self.base_url + pkglist_url
 
-    def get_package_tree(self, kernel_filter=''):
+    def get_package_tree(self, crawler_filter):
         packages = {}
         try:
             repodb_url = self.get_repodb_url()
@@ -84,7 +84,7 @@ class RpmRepository(repo.Repository):
         with tempfile.NamedTemporaryFile() as tf:
             tf.write(repodb)
             tf.flush()
-            for pkg in self.parse_repo_db(tf.name, kernel_filter):
+            for pkg in self.parse_repo_db(tf.name, crawler_filter.kernel_filter):
                 version, url = pkg
                 packages.setdefault(version, set()).add(self.base_url + url)
         return packages

--- a/probe_builder/kernel_crawler/rpm.py
+++ b/probe_builder/kernel_crawler/rpm.py
@@ -113,7 +113,7 @@ class RpmMirror(repo.Mirror):
             return False
         return True
 
-    def list_repos(self):
+    def list_repos(self, crawler_filter):
         dists = requests.get(self.base_url)
         dists.raise_for_status()
         dists = dists.content
@@ -127,9 +127,9 @@ class RpmMirror(repo.Mirror):
                 and not dist.startswith('http')
                 and self.repo_filter(dist)
                 and self.dist_exists(dist)
-                and dist.startswith(self.distro_filter)
+                and dist.startswith(crawler_filter.distro_filter)
                 ]
 
 
-        logger.info("Dists found under {}, filtered by '{}': {}".format(self.base_url, self.distro_filter, fdists))
+        logger.info("Dists found under {}, filtered by '{}': {}".format(self.base_url, crawler_filter.distro_filter, fdists))
         return [RpmRepository(self.dist_url(dist)) for dist in fdists]


### PR DESCRIPTION
add an extra parameter to add the possibility to filter
packages for a given distro release.
The main use case is ubuntu, whose list of packages
(considering all releases) is simply humongous.

This way we can filter by adding -R "impish".