### PR TITLE
propagate build results and produce a nice table

### DIFF
--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -150,7 +150,7 @@ def build(builder_image_prefix,
     for release, future in kernels_futures:
         try:
             res = future.result()
-            if res.kmod_result.failed() or res.ebpf_result.failed():
+            if res.failed():
                 failed += 1
             print(fstr.format(release,
                 res.kmod_result.build_result_string(),
@@ -172,7 +172,7 @@ def build(builder_image_prefix,
         for release, future in kernels_futures:
             try:
                 res = future.result()
-                if res.kmod_result.failed() or res.ebpf_result.failed():
+                if res.failed():
                     print(fstr.format(release,
                         res.kmod_result.build_result_string(),
                         res.ebpf_result.build_result_string()))

--- a/probe_builder/builder/distro/base_builder.py
+++ b/probe_builder/builder/distro/base_builder.py
@@ -28,7 +28,7 @@ class DistroBuilder(object):
         BUILD_EXISTING=1
         BUILD_SKIPPED=2
         BUILD_FAILED=3
-        def __init__(self, build_result, build_time=0, error_log=[]):
+        def __init__(self, build_result, build_time=0, error_log=b''):
             self.build_time = build_time
             self.build_result = build_result
             self.error_log = error_log

--- a/probe_builder/builder/distro/base_builder.py
+++ b/probe_builder/builder/distro/base_builder.py
@@ -50,6 +50,9 @@ class DistroBuilder(object):
             self.kmod_result = kmod_result
             self.ebpf_result = ebpf_result
 
+        def failed(self):
+            return self.kmod_result.failed() or self.ebpf_result.failed()
+
     @staticmethod
     def md5sum(path):
         from hashlib import md5

--- a/probe_builder/builder/distro/base_builder.py
+++ b/probe_builder/builder/distro/base_builder.py
@@ -23,6 +23,32 @@ def to_s(s):
 
 
 class DistroBuilder(object):
+    class ProbeBuildResult(object):
+        BUILD_BUILT=0
+        BUILD_EXISTING=1
+        BUILD_SKIPPED=2
+        BUILD_FAILED=3
+        def __init__(self, build_result, build_time=0, error_log=[]):
+            self.build_time = build_time
+            self.build_result = build_result
+            self.error_log = error_log
+
+        def build_result_string(self):
+            mydict = {
+                self.BUILD_BUILT: 'BUILT',
+                self.BUILD_EXISTING: 'EXISTING',
+                self.BUILD_SKIPPED: 'SKIPPED',
+                self.BUILD_FAILED: 'FAILED',
+            }
+            return mydict[self.build_result]
+
+        def failed(self):
+            return self.build_result == self.BUILD_FAILED
+
+    class KernelBuildResult(object):
+        def __init__(self, kmod_result, ebpf_result):
+            self.kmod_result = kmod_result
+            self.ebpf_result = ebpf_result
 
     @staticmethod
     def md5sum(path):
@@ -51,26 +77,32 @@ class DistroBuilder(object):
             label = 'kmod'
             args = []
 
+        output_dir = workspace.subdir('output')
+        if builder_image.probe_built(probe, output_dir, release, config_hash, bpf):
+            return cls.ProbeBuildResult(cls.ProbeBuildResult.BUILD_EXISTING, 0)
+
         if skip_reason:
             logger.info('Skipping build of {} probe {}-{}: {}'.format(label, release, config_hash, skip_reason))
-            return
+            return cls.ProbeBuildResult(cls.ProbeBuildResult.BUILD_SKIPPED, 0)
 
         #docker.rm(container_name)
         try:
             ts0 = time.time()
-            lines = builder_image.run(workspace, probe, kernel_dir, release, config_hash, container_name, image_name, args)
-        except subprocess.CalledProcessError:
+            stdout = builder_image.run(workspace, probe, kernel_dir, release, config_hash, container_name, image_name, args)
+        except subprocess.CalledProcessError as e:
             took = time.time() - ts0
             logger.error("Build failed for {} probe {}-{} (took {:.3f}s)".format(label, release, config_hash, took))
+            return cls.ProbeBuildResult(cls.ProbeBuildResult.BUILD_FAILED, took, e.output)
         else:
             took = time.time() - ts0
-            output_dir = workspace.subdir('output')
             if builder_image.probe_built(probe, output_dir, release, config_hash, bpf):
                 logger.info("Build for {} probe {}-{} successful (took {:.3f}s)".format(label, release, config_hash, took))
+                return cls.ProbeBuildResult(cls.ProbeBuildResult.BUILD_BUILT, took)
             else:
                 logger.warn("Build for {} probe {}-{} failed silently: no output file found".format(label, release, config_hash))
-                for line in lines:
+                for line in stdout.splitlines(False):
                     logger.warn(make_string(line))
+                return cls.ProbeBuildResult(cls.ProbeBuildResult.BUILD_FAILED, took, stdout)
 
     def build_kernel(self, workspace, probe, builder_distro, release, target):
         config_hash = self.hash_config(release, target)
@@ -78,11 +110,6 @@ class DistroBuilder(object):
 
         kmod_skip_reason = builder_image.skip_build(probe, output_dir, release, config_hash, False)
         ebpf_skip_reason = builder_image.skip_build(probe, output_dir, release, config_hash, True)
-        if kmod_skip_reason and ebpf_skip_reason:
-            logger.info('Skipping build of kmod probe {}-{}: {}'.format(release, config_hash, kmod_skip_reason))
-            logger.info('Skipping build of eBPF probe {}-{}: {}'.format(release, config_hash, ebpf_skip_reason))
-            return
-
         try:
             os.makedirs(output_dir, 0o755)
         except OSError as exc:
@@ -91,7 +118,7 @@ class DistroBuilder(object):
 
         kernel_dir = self.get_kernel_dir(workspace, release, target)
         dockerfile, dockerfile_tag, support_bpf = choose_builder.choose_dockerfile(workspace.builder_source, builder_distro,
-                                                                      kernel_dir)
+                                                                    kernel_dir)
 
         ts0 = time.time()
         # let build() figure out if it actually needs to build or pull anything
@@ -107,10 +134,12 @@ class DistroBuilder(object):
         #container_name = 'sysdig-probe-builder-{}'.format(dockerfile_tag)
         container_name = ''
 
-        self.build_kernel_impl(config_hash, container_name, image_name, kernel_dir, probe, release, workspace, False,
-                               kmod_skip_reason)
-        self.build_kernel_impl(config_hash, container_name, image_name, kernel_dir, probe, release, workspace, True,
-                               ebpf_skip_reason)
+        return self.KernelBuildResult(
+            self.build_kernel_impl(config_hash, container_name, image_name, kernel_dir, probe, release, workspace, False,
+                                kmod_skip_reason),
+            self.build_kernel_impl(config_hash, container_name, image_name, kernel_dir, probe, release, workspace, True,
+                                ebpf_skip_reason),
+        )
 
     def batch_packages(self, kernel_files):
         raise NotImplementedError

--- a/probe_builder/docker.py
+++ b/probe_builder/docker.py
@@ -94,4 +94,4 @@ def is_privileged():
 def remove_dangling_images():
     images = pipe(['docker', 'images', '-q', '-f', 'dangling=true'])
     if images:
-        pipe(['docker', 'rmi'] + images, silence_errors=True)
+        pipe(['docker', 'rmi'] + images.splitlines(False), silence_errors=True)

--- a/probe_builder/spawn.py
+++ b/probe_builder/spawn.py
@@ -20,12 +20,12 @@ def pipe(cmd, silence_errors=False, cwd=None):
         logger.warn('{} returned error code {}'.format(cmd_string, child.returncode))
         for line in stdout.splitlines(False):
             logger.warn(make_string(line))
-        raise subprocess.CalledProcessError(child.returncode, cmd_string)
+        raise subprocess.CalledProcessError(child.returncode, cmd_string, stdout)
     else:
         lines = stdout.splitlines(False)
         for line in lines:
             logger.debug(make_string(line))
-        return lines
+        return make_string(stdout)
 
 
 def json_pipe(cmd, silence_errors=False, cwd=None):

--- a/probe_builder/spawn.py
+++ b/probe_builder/spawn.py
@@ -25,7 +25,7 @@ def pipe(cmd, silence_errors=False, cwd=None):
         lines = stdout.splitlines(False)
         for line in lines:
             logger.debug(make_string(line))
-        return make_string(stdout)
+        return stdout
 
 
 def json_pipe(cmd, silence_errors=False, cwd=None):


### PR DESCRIPTION
* Add exception handling in futures

* Propagate build results for each built kernel, and produce a nice textual table with two results for each kernel built: one for kmod and one for ebpf.

* Also add a second table with failed kernels only, so they become easier to spot

* Set the exit code to 1 in case of failures