### PR TITLE
fix(debian): use clang-7 with gcc 6.3

### DIFF
--- a/Dockerfile.debian-gcc6.3-bpf
+++ b/Dockerfile.debian-gcc6.3-bpf
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 	&& apt-get clean
 
 # Enforce usage of clang 7, which is more recent
-# than the standard 3.8.1-24 that comes with strecth
+# than the standard 3.8.1-24 that comes with stretch
 # and might raise
 # clang: error: unknown argument: '-fno-jump-tables'
 ENV CLANG clang-7

--- a/Dockerfile.debian-gcc6.3-bpf
+++ b/Dockerfile.debian-gcc6.3-bpf
@@ -9,9 +9,16 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 	libelf-dev \
 	make \
 	pkg-config \
-	clang \
-	llvm \
+	clang-7 \
+	llvm-7 \
 	&& apt-get clean
+
+# Enforce usage of clang 7, which is more recent
+# than the standard 3.8.1-24 that comes with strecth
+# and might raise
+# clang: error: unknown argument: '-fno-jump-tables'
+ENV CLANG clang-7
+ENV LLC llc-7
 
 ADD builder-entrypoint.sh /
 WORKDIR /build/probe


### PR DESCRIPTION
4.19.0-0.bpo.9 and 4.19.0-0.bpo.19 kernels
are currently failing to compile eBPF probes due to: 

clang: error: unknown argument: '-fno-jump-tables'

Use clang-7 as opposed to 3.8.1 on the affected builder.