### PR TITLE
fix(amazonlinux2): skip first 5.10.x kernels without wrapper

### DIFF
--- a/probe_builder/builder/builder_image.py
+++ b/probe_builder/builder/builder_image.py
@@ -76,6 +76,28 @@ SKIPPED_KERNELS = [
     ("5.8.0-1023-aws", "3f7746be1bef4c3f68f5465d8453fa4d"),
 ]
 
+
+# These AmazonLinux2 kernels were built with gcc 10.
+# Apparently, starting with 5.10.50, they started creating a
+# wrapper /usr/src/kernels/*/Makefile containing the following:
+#
+# GCC_VER=gcc10-
+# CROSS_COMPILE=$(GCC_VER)
+# HOSTCC=$(GCC_VER)gcc
+# HOSTCXX=$(GCC_VER)g++
+# CC=$(GCC_VER)gcc
+# LD=$(GCC_VER)ld.bfd
+#
+# which would then call the renamed Makefile->Makefile.kernel
+# so these 4 guys are essentially broken so we just exclude them
+#
+SKIPPED_AL2_KMOD_KERNELS = [
+    ("5.10.47-39.130.amzn2.x86_64", "c2f4afab82d814c0917176b3e8bbc5eb"),
+    ("5.10.35-31.135.amzn2.x86_64", "72045c5b99c571a8dfffc5b537912864"),
+    ("5.10.29-27.126.amzn2.x86_64", "587d839a59252859091e65c52f202a92"),
+    ("5.10.29-27.128.amzn2.x86_64", "94f8e35b13a393ca58b765bd738e2562"),
+]
+
 def probe_built(probe, output_dir, kernel_release, config_hash, bpf):
     probe_file_name = probe_output_file(probe, kernel_release, config_hash, bpf)
     return os.path.exists(os.path.join(output_dir, probe_file_name))
@@ -90,3 +112,6 @@ def skip_build(probe, output_dir, kernel_release, config_hash, bpf):
         kernel_version = Version(kernel_release)
         if kernel_version < Version('4.14'):
             return 'Kernel {} too old to support eBPF (need at least 4.14)'.format(kernel_release)
+    else:
+        if (kernel_release, config_hash) in SKIPPED_AL2_KMOD_KERNELS:
+            return "AmazonLinux2 kernel built with gcc-10 but without wrapper Makefile"


### PR DESCRIPTION
Apparently, 5.10.x kernels shipped with AmazonLinux2 are compiled with gcc-10 which is NOT the default compiler.
Starting with 5.10.50, they started creating a
wrapper /usr/src/kernels/*/Makefile containing the following:

GCC_VER=gcc10-
CROSS_COMPILE=$(GCC_VER)
HOSTCC=$(GCC_VER)gcc
HOSTCXX=$(GCC_VER)g++
CC=$(GCC_VER)gcc
LD=$(GCC_VER)ld.bfd

which would then call the renamed Makefile->Makefile.kernel

But before then, only the standard Makefile was used, which would then use the default toolchain (gcc7.3), leading to failure.

Since it's just 4 kernels which are quite outdated, and they probably never built in the first place,
we're just going to ditch them.