### PR TITLE
add flag to allow overwriting of probes

### DIFF
--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -109,6 +109,7 @@ def cli(debug):
 @click.option('-j', '--jobs', type=click.INT, default=len(os.sched_getaffinity(0)))
 @click.option('-k', '--kernel-type', type=click.Choice(sorted(CLI_DISTROS.keys())))
 @click.option('-f', '--filter', default='')
+@click.option('-o', '--overwrite', is_flag=True)
 @click.option('-p', '--probe-name')
 @click.option('-r', '--retries', type=click.INT, default=1)
 @click.option('-s', '--source-dir')
@@ -116,7 +117,8 @@ def cli(debug):
 @click.option('-v', '--probe-version')
 @click.argument('package', nargs=-1)
 def build(builder_image_prefix,
-          download_concurrency, jobs, kernel_type, filter, probe_name, retries,
+          download_concurrency, jobs, kernel_type, filter, overwrite,
+          probe_name, retries,
           source_dir, download_timeout, probe_version, package):
     workspace_dir = os.getcwd()
     builder_source = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -135,7 +137,7 @@ def build(builder_image_prefix,
     with ThreadPoolExecutor(max_workers=jobs) as executor:
         kernels_futures = []
         for release, target in kernel_dirs:
-            future = executor.submit(distro_builder.build_kernel, workspace, probe, distro.builder_distro, release, target)
+            future = executor.submit(distro_builder.build_kernel, workspace, probe, distro.builder_distro, release, target, overwrite)
             kernels_futures.append((release, future))
 
 

--- a/probe_builder/builder/builder_image.py
+++ b/probe_builder/builder/builder_image.py
@@ -103,8 +103,8 @@ def probe_built(probe, output_dir, kernel_release, config_hash, bpf):
     probe_file_name = probe_output_file(probe, kernel_release, config_hash, bpf)
     return os.path.exists(os.path.join(output_dir, probe_file_name))
 
-def skip_build(probe, output_dir, kernel_release, config_hash, bpf):
-    if probe_built(probe, output_dir, kernel_release, config_hash, bpf):
+def skip_build(probe, output_dir, kernel_release, config_hash, bpf, overwrite=False):
+    if not overwrite and probe_built(probe, output_dir, kernel_release, config_hash, bpf):
         return "Already built"
 
     if (kernel_release, config_hash) in SKIPPED_KERNELS:

--- a/probe_builder/builder/distro/base_builder.py
+++ b/probe_builder/builder/distro/base_builder.py
@@ -72,7 +72,7 @@ class DistroBuilder(object):
 
     @classmethod
     def build_kernel_impl(cls, config_hash, container_name, image_name, kernel_dir, probe, release, workspace, bpf,
-                          skip_reason):
+                          skip_reason, overwrite=False):
         if bpf:
             label = 'eBPF'
             args = ['bpf']
@@ -81,7 +81,7 @@ class DistroBuilder(object):
             args = []
 
         output_dir = workspace.subdir('output')
-        if builder_image.probe_built(probe, output_dir, release, config_hash, bpf):
+        if not overwrite and builder_image.probe_built(probe, output_dir, release, config_hash, bpf):
             return cls.ProbeBuildResult(cls.ProbeBuildResult.BUILD_EXISTING, 0)
 
         if skip_reason:
@@ -107,12 +107,12 @@ class DistroBuilder(object):
                     logger.warn(make_string(line))
                 return cls.ProbeBuildResult(cls.ProbeBuildResult.BUILD_FAILED, took, stdout)
 
-    def build_kernel(self, workspace, probe, builder_distro, release, target):
+    def build_kernel(self, workspace, probe, builder_distro, release, target, overwrite=False):
         config_hash = self.hash_config(release, target)
         output_dir = workspace.subdir('output')
 
-        kmod_skip_reason = builder_image.skip_build(probe, output_dir, release, config_hash, False)
-        ebpf_skip_reason = builder_image.skip_build(probe, output_dir, release, config_hash, True)
+        kmod_skip_reason = builder_image.skip_build(probe, output_dir, release, config_hash, False, overwrite)
+        ebpf_skip_reason = builder_image.skip_build(probe, output_dir, release, config_hash, True, overwrite)
         try:
             os.makedirs(output_dir, 0o755)
         except OSError as exc:
@@ -139,9 +139,9 @@ class DistroBuilder(object):
 
         return self.KernelBuildResult(
             self.build_kernel_impl(config_hash, container_name, image_name, kernel_dir, probe, release, workspace, False,
-                                kmod_skip_reason),
+                                kmod_skip_reason, overwrite),
             self.build_kernel_impl(config_hash, container_name, image_name, kernel_dir, probe, release, workspace, True,
-                                ebpf_skip_reason),
+                                ebpf_skip_reason, overwrite),
         )
 
     def batch_packages(self, kernel_files):

--- a/probe_builder/builder/distro/flatcar.py
+++ b/probe_builder/builder/distro/flatcar.py
@@ -47,7 +47,7 @@ class FlatcarBuilder(DistroBuilder):
 
     @classmethod
     def build_kernel_impl(cls, config_hash, container_name, image_name, kernel_dir, probe, release, workspace, bpf,
-                          skip_reason):
+                          skip_reason, overwrite=False):
         if bpf:
             label = 'eBPF'
             args = ['bpf']


### PR DESCRIPTION
For obvious optimization reasons, we're currently skipping building probes in case the required object file already exists. However, there might be cases where we need to rebuild probes because we e.g. made changes to the Dockerfiles.

Add a '-o/--overwrite' flag for this purpose.