### PR TITLE
ubuntu: enforce usage of clang-14

### DIFF
--- a/Dockerfile.ubuntu-gcc11.2-bpf
+++ b/Dockerfile.ubuntu-gcc11.2-bpf
@@ -11,8 +11,8 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main m
 		libelf-dev \
 		make \
 		pkg-config \
-		clang \
-		llvm \
+		clang-14 \
+		llvm-14 \
 		&& apt-get clean
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 && \

--- a/Dockerfile.ubuntu-gcc12.2-bpf
+++ b/Dockerfile.ubuntu-gcc12.2-bpf
@@ -11,9 +11,14 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu/ kinetic-proposed restricted main
 		libelf-dev \
 		make \
 		pkg-config \
-		clang \
-		llvm \
+		clang-14 \
+		llvm-14 \
 		&& apt-get clean
+
+# Enforce usage of clang 14, since clang 15 seems to
+# raise a lot of verifier issues
+ENV CLANG clang-14
+ENV LLC llc-14
 
 ADD builder-entrypoint.sh /
 WORKDIR /build/probe


### PR DESCRIPTION
Ubuntu (and many other distros) have recently started deploying clang-15 as the default clang.
Since the resulting probes might not pass the verifier, we can just enforce the usage of clang-14 when prebuiling probes.