### PR TITLE
fedora: drop stale mirrors.kernel.org

### DIFF
--- a/probe_builder/kernel_crawler/fedora.py
+++ b/probe_builder/kernel_crawler/fedora.py
@@ -12,8 +12,12 @@ def repo_filter(version):
 class FedoraMirror(repo.Distro):
     def __init__(self):
         mirrors = [
-            rpm.RpmMirror('https://mirrors.kernel.org/fedora/releases/', 'Everything/x86_64/os/', repo_filter),
-            rpm.RpmMirror('https://mirrors.kernel.org/fedora/updates/', 'Everything/x86_64/', repo_filter),
+            # Obtained by picking one from https://mirrors.fedoraproject.org/metalink?repo=fedora-37&arch=x86_64
+            ### -> http://download-ib01.fedoraproject.org/pub/fedora/linux/releases/37/Everything/x86_64/os/repodata/repomd.xml
+            rpm.RpmMirror('http://download-ib01.fedoraproject.org/pub/fedora/linux/releases/', 'Everything/x86_64/os/', repo_filter),
+            # https://mirrors.fedoraproject.org/metalink?repo=updates-released-f37&arch=x86_64
+            ### -> http://download-ib01.fedoraproject.org/pub/fedora/linux/updates/37/Everything/x86_64/repodata/repomd.xml
+            rpm.RpmMirror('http://download-ib01.fedoraproject.org/pub/fedora/linux/updates/', 'Everything/x86_64/', repo_filter),
         ]
         super(FedoraMirror, self).__init__(mirrors)
 


### PR DESCRIPTION
mirrors.kernel.org has been failing to publish
the most up-to-date kernels for fedora 36 and 37.

A better suited approach would involve parsing the metalinks, but for the time being just pick one mirror.