### PR TITLE
[wip] sign kernel modules

### DIFF
--- a/Dockerfile.centos-gcc4.8
+++ b/Dockerfile.centos-gcc4.8
@@ -10,6 +10,7 @@ RUN yum -y install \
 	flex \
 	make \
 	cmake \
+	openssl \
 	elfutils-devel \
 	python-lxml && yum clean all
 

--- a/builder-entrypoint.sh
+++ b/builder-entrypoint.sh
@@ -9,6 +9,7 @@
 # PROBE_DEVICE_NAME
 # PROBE_NAME
 # PROBE_VERSION
+# SIGN_FILE_HASH_ALGO
 
 # optional env vars
 # CLANG
@@ -54,6 +55,16 @@ build_kmod() {
 	if [ "$KO_VERSION" != "$KERNEL_RELEASE" ]; then
 		echo "Corrupted probe, KO_VERSION " $KO_VERSION ", KERNEL_RELEASE " $KERNEL_RELEASE
 		exit 1
+	fi
+
+	if [ -n "${SIGN_FILE_HASH_ALGO}" ]; then
+		echo "Signing generated kernel module"
+		${KERNELDIR}/scripts/sign-file ${SIGN_FILE_HASH_ALGO} \
+			/code/sysdig-ro/signing-key/key.priv \
+			/code/sysdig-ro/signing-key/key.der \
+			driver/${PROBE_NAME}.ko
+	else
+		echo "Kernel module will NOT be signed"
 	fi
 
 	cp driver/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko

--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -114,10 +114,11 @@ def cli(debug):
 @click.option('-s', '--source-dir')
 @click.option('-t', '--download-timeout', type=click.FLOAT)
 @click.option('-v', '--probe-version')
+@click.option('-x', '--sign', is_flag=True)
 @click.argument('package', nargs=-1)
 def build(builder_image_prefix,
           download_concurrency, jobs, kernel_type, filter, probe_name, retries,
-          source_dir, download_timeout, probe_version, package):
+          source_dir, download_timeout, probe_version, sign, package):
     workspace_dir = os.getcwd()
     builder_source = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -135,7 +136,7 @@ def build(builder_image_prefix,
     with ThreadPoolExecutor(max_workers=jobs) as executor:
         kernels_futures = []
         for release, target in kernel_dirs:
-            future = executor.submit(distro_builder.build_kernel, workspace, probe, distro.builder_distro, release, target)
+            future = executor.submit(distro_builder.build_kernel, workspace, probe, distro.builder_distro, release, target, sign)
             kernels_futures.append((release, future))
 
 

--- a/probe_builder/builder/builder_image.py
+++ b/probe_builder/builder/builder_image.py
@@ -39,7 +39,7 @@ def build(workspace, dockerfile, dockerfile_tag):
         return obj
 
 def run(workspace, probe, kernel_dir, kernel_release,
-        config_hash, container_name, image_name, args):
+        config_hash, container_name, image_name, sign_file_hash_algo, args):
     volumes = [
         docker.DockerVolume(workspace.host_dir(probe.sysdig_dir), '/code/sysdig-ro', True),
         docker.DockerVolume(workspace.host_workspace(), '/build/probe', True),
@@ -53,7 +53,8 @@ def run(workspace, probe, kernel_dir, kernel_release,
         docker.EnvVar('KERNELDIR', kernel_dir.replace(workspace.workspace, '/build/probe/')),
         docker.EnvVar('KERNEL_RELEASE', kernel_release),
         docker.EnvVar('HASH', config_hash),
-        docker.EnvVar('HASH_ORIG', config_hash)
+        docker.EnvVar('HASH_ORIG', config_hash),
+        docker.EnvVar('SIGN_FILE_HASH_ALGO', sign_file_hash_algo),
     ]
 
     return docker.run(image_name, volumes, args, env, name=container_name)

--- a/probe_builder/builder/distro/base_builder.py
+++ b/probe_builder/builder/distro/base_builder.py
@@ -64,11 +64,15 @@ class DistroBuilder(object):
 
     @staticmethod
     def config_module_sig_hash(path):
+        # Look up the default hashing algorithm for module signing from within the config file
+        # Notes:
+        # 1. If not present, use empty string (no signing)
+        # 2. Remove the quotes
         with open(path, 'r') as f:
             config_string = '[DEFAULT]\n' + f.read()
         config = configparser.ConfigParser()
         config.read_string(config_string)
-        return config['DEFAULT']['CONFIG_MODULE_SIG_HASH'].replace('"','')
+        return config['DEFAULT'].get('CONFIG_MODULE_SIG_HASH','').replace('"','')
 
     def unpack_kernels(self, workspace, distro, kernels):
         raise NotImplementedError

--- a/probe_builder/builder/distro/centos.py
+++ b/probe_builder/builder/distro/centos.py
@@ -33,6 +33,17 @@ class CentosBuilder(DistroBuilder):
         except IOError:
             return self.md5sum(os.path.join(target, 'lib/modules/{}/config'.format(release)))
 
+    def sign_file_hash_algo(self, release, target):
+        boot = os.path.join(target, 'boot/config-{}'.format(release))
+        lib_modules = os.path.join(target, 'lib/modules/{}/config'.format(release))
+
+        if os.path.isfile(boot):
+            return self.config_module_sig_hash(boot)
+        elif os.path.isfile(lib_modules):
+            return self.config_module_sig_hash(lib_modules)
+        else:
+            raise Exception("No file found!")
+
     def get_kernel_dir(self, workspace, release, target):
         return workspace.subdir(target, 'usr/src/kernels', release)
 

--- a/probe_builder/builder/distro/debian.py
+++ b/probe_builder/builder/distro/debian.py
@@ -88,6 +88,9 @@ class DebianBuilder(DistroBuilder):
     def hash_config(self, release, target):
         return self.md5sum(os.path.join(target, 'boot/config-{}'.format(release)))
 
+    def sign_file_hash_algo(self, release, target):
+        return self.config_module_sig_hash(os.path.join(target, 'boot/config-{}'.format(release)))
+
     def get_kernel_dir(self, workspace, release, target):
         return workspace.subdir(target, 'usr/src/linux-headers-{}'.format(release))
 

--- a/probe_builder/builder/distro/flatcar.py
+++ b/probe_builder/builder/distro/flatcar.py
@@ -32,6 +32,9 @@ class FlatcarBuilder(DistroBuilder):
     def hash_config(self, release, target):
         return self.md5sum(os.path.join(target, 'config'.format(release)))
 
+    def sign_file_hash_algo(self, release, target):
+        return self.config_module_sig_hash(os.path.join(target, 'config'.format(release)))
+
     def get_kernel_dir(self, workspace, release, target):
         versions = glob.glob(os.path.join(target, 'modules/*/build'))
         if len(versions) != 1:

--- a/probe_builder/builder/distro/ubuntu.py
+++ b/probe_builder/builder/distro/ubuntu.py
@@ -68,6 +68,9 @@ class UbuntuBuilder(DistroBuilder):
     def hash_config(self, release, target):
         return self.md5sum(os.path.join(target, 'boot/config-{}'.format(release)))
 
+    def sign_file_hash_algo(self, release, target):
+        return self.config_module_sig_hash(os.path.join(target, 'boot/config-{}'.format(release)))
+
     def get_kernel_dir(self, workspace, release, target):
         return workspace.subdir(target, 'usr/src/linux-headers-{}'.format(release))
 


### PR DESCRIPTION
This is a WIP/Proof-of-Concept change to introduce kernel module signing.
The actual signing is performed by the in-tree script sign-file.
The private key and the certificate must be provided in the same directory as the libs/ checkout, under a specially created directory signed-key/, i.e.

 + agent-libs
   + cmake
   + driver
   + proposals
   + signing-key   <-----
   + test
   + userspace

and must be called:
   + key.priv (private key in PEM format)
   + key.der  (certificate in DER format)

NOTE: this was done in order not to create any additional paths to mount as volume, (first to the outer container, and then to the specific container).

ALSO NOTE: on newer kernels the sign-file would be a C program which also accepts a PEM textual file for the certificate but older kernels use a perl script which can only read a DER binary file, so for compatibility reason this _must_ be a binary file.

The top-level python script must be called with the '-x/--sign' flag in order for module signing to be enabled.
Since different kernels might use a different hashing algorithm (sha256, sha512, etc..), the one chosen by the target kernel is read from the kernel config file under CONFIG_MODULE_SIG_HASH.

This value is then passed over to the downstream builder as SIGN_FILE_HASH_ALGO.
When '-x/--sign' is not specified, this is left empty and the module is NOT signed.