### PR TITLE
fix(ubuntu,jammy): fix usage of clang-14

### DIFF
--- a/Dockerfile.ubuntu-gcc11.2-bpf
+++ b/Dockerfile.ubuntu-gcc11.2-bpf
@@ -18,6 +18,14 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main m
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11
 
+# Enforce usage of clang 14, since clang 15 seems to
+# raise a lot of verifier issues
+# Notice how at the time of writing clang would just
+# link to clang-14 (as opposed to kinetic which has
+# apparently migrated to clang-15)
+ENV CLANG clang-14
+ENV LLC llc-14
+
 ADD builder-entrypoint.sh /
 WORKDIR /build/probe
 ENTRYPOINT [ "/builder-entrypoint.sh" ]


### PR DESCRIPTION
With PR #75 we enforced usage of clang-14 for
ubuntu jammy and kinetic builders.
However, we forgot to add the explicit variables
for jammy so all builds are bound to fail.
Fix it.