### PR TITLE
Moved CentOS Stream 8 and 9 to a separated class

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Distributions supported by the kernel crawler:
  - AmazonLinux
  - AmazonLinux2
  - CentOS
+ - CentOS Stream (8 and 9)
  - Debian
  - Fedora
  - Flatcar

--- a/probe_builder/kernel_crawler/__init__.py
+++ b/probe_builder/kernel_crawler/__init__.py
@@ -1,6 +1,6 @@
 from .almalinux import AlmaLinuxMirror
 from .amazonlinux import AmazonLinux1Mirror, AmazonLinux2Mirror, AmazonLinux2022Mirror
-from .centos import CentosMirror
+from .centos import CentosMirror, CentosStreamMirror
 from .fedora import FedoraMirror
 from .oracle import Oracle6Mirror, Oracle7Mirror, Oracle8Mirror, Oracle9Mirror
 from .photon_os import PhotonOsMirror
@@ -17,6 +17,7 @@ DISTROS = {
     'AmazonLinux2': AmazonLinux2Mirror,
     'AmazonLinux2022': AmazonLinux2022Mirror,
     'CentOS': CentosMirror,
+    'CentOSStream': CentosStreamMirror,
     'Fedora': FedoraMirror,
     'Oracle6': Oracle6Mirror,
     'Oracle7': Oracle7Mirror,

--- a/probe_builder/kernel_crawler/centos.py
+++ b/probe_builder/kernel_crawler/centos.py
@@ -7,6 +7,9 @@ def v7_only(ver):
 def v8_only(ver):
     return ver.startswith('8')
 
+def v8_stream(ver):
+    return ver.startswith('8-stream')
+
 def v9_only(ver):
     return ver.startswith('9')
 
@@ -23,11 +26,18 @@ class CentosMirror(repo.Distro):
             rpm.RpmMirror('http://linuxsoft.cern.ch/centos-vault/', 'os/x86_64/', v6_or_v7),
             rpm.RpmMirror('http://linuxsoft.cern.ch/centos-vault/', 'updates/x86_64/', v6_or_v7),
             rpm.RpmMirror('http://linuxsoft.cern.ch/centos-vault/', 'BaseOS/x86_64/os/', v8_only),
-            # Some CentOS 8 kernels are available only on vault.centos.org or archive.kernel.org
-            rpm.RpmMirror('http://vault.centos.org/centos/', 'BaseOS/x86_64/os/', v8_only),
-            rpm.RpmMirror('http://archive.kernel.org/centos/', 'BaseOS/x86_64/os/', v8_only),
-            # It seems like centos stream uses /AppStream for kernel-devel, instead of BaseOS
+        ]
+        super(CentosMirror, self).__init__(mirrors)
+
+class CentosStreamMirror(repo.Distro):
+    def __init__(self):
+        mirrors = [
+            # CentOS 8 Stream
+            rpm.RpmMirror('http://mirror.centos.org/centos/', 'BaseOS/x86_64/os/', v8_stream),
+            rpm.RpmMirror('http://mirror.centos.org/centos/', 'AppStream/x86_64/os/', v8_stream),
+
+            # CentOS 9 Stream
             rpm.RpmMirror('http://mirror.stream.centos.org/', 'BaseOS/x86_64/os/', v9_only),
             rpm.RpmMirror('http://mirror.stream.centos.org/', 'AppStream/x86_64/os/', v9_only),
         ]
-        super(CentosMirror, self).__init__(mirrors)
+        super(CentosStreamMirror, self).__init__(mirrors)


### PR DESCRIPTION
- Added CentOS Stream as flag for `-C CentOSStream`
- Moved CentOS Stream 8 and 9 to a separated python class, this would help with the performances when searching for a specific kernel version

Centos 8 Stream
```
root@dcknuc:~/kernel-crawler# time docker run -v /var/run/docker.sock:/var/run/docker.sock sysdig-probe-builder -C CentOSStream 4.18.0-448.el8 | grep '^ '
Checking repositories
Listing packages
 http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/kernel-core-4.18.0-448.el8.x86_64.rpm
 http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/kernel-devel-4.18.0-448.el8.x86_64.rpm
 http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/kernel-4.18.0-448.el8.x86_64.rpm
 http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/kernel-modules-4.18.0-448.el8.x86_64.rpm

real	0m32.365s
user	0m0.304s
sys	0m0.134s
```

Centos 9 Stream
```
root@dcknuc:~/kernel-crawler# time docker run -v /var/run/docker.sock:/var/run/docker.sock sysdig-probe-builder -C CentOSStream 5.14.0-252.el9 | grep '^ '
Checking repositories
Listing packages
 http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/kernel-5.14.0-252.el9.x86_64.rpm
 http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/kernel-core-5.14.0-252.el9.x86_64.rpm
 http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/kernel-modules-5.14.0-252.el9.x86_64.rpm
 http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/kernel-devel-5.14.0-252.el9.x86_64.rpm

real	0m41.178s
user	0m0.115s
sys	0m0.099s
```