### PR TITLE
Add CentOSStream distro for build command in addition to crawl

### DIFF
--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -80,6 +80,7 @@ CLI_DISTROS = {
     'AmazonLinux2': CrawlDistro('amazonlinux2', 'centos', 'AmazonLinux2'),
     'AmazonLinux2022': CrawlDistro('amazonlinux2022', 'centos', 'AmazonLinux2022'),
     'CentOS': CrawlDistro('centos', 'centos', 'CentOS'),
+    'CentOSStream': CrawlDistro('centosstream', 'centos', 'CentOSStream'),
     'Debian': CrawlDistro('debian', 'debian', 'Debian'),
     'Fedora': CrawlDistro('fedora', 'centos', 'Fedora'),
     'Flatcar': CrawlDistro('flatcar', 'flatcar', 'Flatcar'),


### PR DESCRIPTION
While creating this PR https://github.com/draios/probe-builder/pull/81 I forgot to add CentOS Stream also for non-custom distro crawl/build
