### PR TITLE
crawling(centos): move from cern.ch to archive.kernel.org

### DIFF
--- a/probe_builder/kernel_crawler/centos.py
+++ b/probe_builder/kernel_crawler/centos.py
@@ -23,9 +23,9 @@ class CentosMirror(repo.Distro):
             rpm.RpmMirror('http://mirror.centos.org/centos/', 'updates/x86_64/', v7_only),
             # CentOS 8 reached end-of-life at the end of 2021, so no point looking for it
             # rpm.RpmMirror('http://mirror.centos.org/centos/', 'BaseOS/x86_64/os/', v8_only),
-            rpm.RpmMirror('http://linuxsoft.cern.ch/centos-vault/', 'os/x86_64/', v6_or_v7),
-            rpm.RpmMirror('http://linuxsoft.cern.ch/centos-vault/', 'updates/x86_64/', v6_or_v7),
-            rpm.RpmMirror('http://linuxsoft.cern.ch/centos-vault/', 'BaseOS/x86_64/os/', v8_only),
+            rpm.RpmMirror('http://archive.kernel.org/centos-vault/', 'os/x86_64/', v6_or_v7),
+            rpm.RpmMirror('http://archive.kernel.org/centos-vault/', 'updates/x86_64/', v6_or_v7),
+            rpm.RpmMirror('http://archive.kernel.org/centos-vault/', 'BaseOS/x86_64/os/', v8_only),
         ]
         super(CentosMirror, self).__init__(mirrors)
 


### PR DESCRIPTION
we've been abusing CERN's servers for a long time. 
archive.kernel.org seems more appropriate and probably has lots of closer mirrors.