### PR TITLE
fix(debian): fix patching Makefiles, take 2

### DIFF
--- a/probe_builder/builder/distro/debian.py
+++ b/probe_builder/builder/distro/debian.py
@@ -77,7 +77,11 @@ class DebianBuilder(DistroBuilder):
             target_in_container = target.replace(workspace.workspace, '/build/probe')
             with open(makefile) as fp:
                 orig = fp.read()
-            patched = orig.replace('include /usr/src', 'include ' + os.path.join(target_in_container, 'usr/src'))
+            patched = orig
+            newpath = os.path.join(target_in_container, 'usr/src')
+            patched = patched.replace('include /usr/src', 'include ' + newpath)
+            patched = patched.replace('-C /usr/src', '-C ' + newpath)
+            patched = patched.replace('O=/usr/src', 'O=' + newpath)
             if patched != orig:
                 with open(makefile, 'w') as fp:
                     fp.write("# patched by sysdig-probe-builder\n")


### PR DESCRIPTION
With #70 we changed the way we patch debian Makefiles. However, the wrong assumption was made that all Makefile's would have an "include /usr.." line, whereas in reality there is also a second way:

MAKEARGS := -C /usr/src/linux-headers-4.19.0-20-common O=/usr/src/linux-headers-4.19.0-20-arm64

So adapt the patching mechanism accordingly.