### PR TITLE
chore(toolkit): silence bsdtar

### DIFF
--- a/toolkit-entrypoint.sh
+++ b/toolkit-entrypoint.sh
@@ -42,7 +42,7 @@ unpack_rpm()
 	# rpm2cpio "$KERNEL_PACKAGE" | (cd "$OUTPUT_DIR" && cpio -idm)
 	# since alpine ships a bsdtar which seems perfectly capable (in and of itself)
 	# of extracting the files we need from an .rpm file, use that instead
-	bsdtar xvf "$KERNEL_PACKAGE" -C "$OUTPUT_DIR"
+	bsdtar xf "$KERNEL_PACKAGE" -C "$OUTPUT_DIR"
 }
 
 case "$1" in


### PR DESCRIPTION
with #61 we replace rpm2cpio with bsdtar, but left the (v)erbose option on.
This creates a lot of uneed output. Drop it.