### PR TITLE
fix(flatcar): fix builder

### DIFF
--- a/probe_builder/builder/distro/flatcar.py
+++ b/probe_builder/builder/distro/flatcar.py
@@ -69,7 +69,7 @@ class FlatcarBuilder(DistroBuilder):
         else:
             logger.info("Build for {} probe {}-{} ({}) successful".format(label, coreos_kernel_release, config_hash, release))
 
-    def crawl(self, workspace, distro, crawler_distro, download_config=None):
+    def crawl(self, workspace, distro, crawler_distro, download_config=None, filter=''):
         kernels = crawl_kernels(crawler_distro)
         try:
             os.makedirs(workspace.subdir(distro.distro))

--- a/probe_builder/builder/distro/flatcar.py
+++ b/probe_builder/builder/distro/flatcar.py
@@ -70,7 +70,7 @@ class FlatcarBuilder(DistroBuilder):
             logger.info("Build for {} probe {}-{} ({}) successful".format(label, coreos_kernel_release, config_hash, release))
 
     def crawl(self, workspace, distro, crawler_distro, download_config=None, filter=''):
-        kernels = crawl_kernels(crawler_distro)
+        kernels = crawl_kernels(crawler_distro, filter)
         try:
             os.makedirs(workspace.subdir(distro.distro))
         except OSError as exc:


### PR DESCRIPTION
with #41 we add kernel filtering, but poor flatcar guy got completely forgotten so it's been broken ever since. 
Stop at once the discrimination against it and fix it so it can rest in peace and keep being ignored but in a working state.