### PR TITLE
fix crawling bug introduced by distro filtering

### DIFF
--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -200,7 +200,7 @@ def build(builder_image_prefix,
 @click.argument('kernel_filter', required=False, default='')
 def crawl(distro, distro_filter='', kernel_filter=''):
     crawler_filter = kernel_crawler.repo.CrawlerFilter(distro_filter=distro_filter, kernel_filter=kernel_filter)
-    kernels = crawl_kernels(distro, distro_filter, crawler_filter=crawler_filter)
+    kernels = crawl_kernels(distro, crawler_filter=crawler_filter)
     for release, packages in kernels.items():
         print('=== {} ==='.format(release))
         for pkg in packages:


### PR DESCRIPTION
With #68 we added support for distro filtering but a small bug slipped through the crack causing the following error when using the crawling operation:

  File "/builder/probe_builder/__init__.py", line 203, in crawl
    kernels = crawl_kernels(distro, distro_filter, crawler_filter=crawler_filter)
TypeError: crawl_kernels() got multiple values for argument 'crawler_filter'

Fix it.