### PR TITLE
fix(ebpf): implement architecture-specific minimal supported kernels

### DIFF
--- a/probe_builder/builder/builder_image.py
+++ b/probe_builder/builder/builder_image.py
@@ -98,6 +98,12 @@ SKIPPED_AL2_KMOD_KERNELS = [
     ("5.10.29-27.128.amzn2.x86_64", "94f8e35b13a393ca58b765bd738e2562"),
 ]
 
+MIN_EBPF_SUPPORTED_RELEASE = {
+    'x86_64': '4.14',
+    'aarch64': '4.17',
+    's390x': '5.5',
+}
+
 def probe_built(mach, probe, output_dir, kernel_release, config_hash, bpf):
     probe_file_name = probe_output_file(mach, probe, kernel_release, config_hash, bpf)
     return os.path.exists(os.path.join(output_dir, probe_file_name))
@@ -110,8 +116,9 @@ def skip_build(mach, probe, output_dir, kernel_release, config_hash, bpf):
         return "Unsupported kernel"
     if bpf:
         kernel_version = Version(kernel_release)
-        if kernel_version < Version('4.14'):
-            return 'Kernel {} too old to support eBPF (need at least 4.14)'.format(kernel_release)
+        min_release = MIN_EBPF_SUPPORTED_RELEASE[mach]
+        if kernel_version < Version(min_release):
+            return 'Kernel {} too old to support eBPF (need at least {} for {})'.format(kernel_release, min_release, mach)
     else:
         if (kernel_release, config_hash) in SKIPPED_AL2_KMOD_KERNELS:
             return "AmazonLinux2 kernel built with gcc-10 but without wrapper Makefile"


### PR DESCRIPTION
Looks like 4.14 is the lower bound of x86_64,
whereas other architectures have different values.

See https://github.com/falcosecurity/libs#drivers-officially-supported-architectures

Implement that gating.