### PR TITLE
feat(oracle8): add UEK R7 kernels to OracleLinux 8

### DIFF
--- a/probe_builder/kernel_crawler/oracle.py
+++ b/probe_builder/kernel_crawler/oracle.py
@@ -42,6 +42,7 @@ class Oracle8Mirror(repo.Distro):
     OL8_REPOS = [
         'http://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/{}/',
         'http://yum.oracle.com/repo/OracleLinux/OL8/UEKR6/{}/',
+        'http://yum.oracle.com/repo/OracleLinux/OL8/UEKR7/{}/',
     ]
 
     def list_repos(self, crawler_filter):


### PR DESCRIPTION
Oracle Linux 8 also supports UEK R7 kernels (5.15.x) in addition to UEK R6 (5.4.x). Crawl them, too.