### PR TITLE
allow for driver sources coming from agent-kmodule.tgz

### DIFF
--- a/builder-entrypoint.sh
+++ b/builder-entrypoint.sh
@@ -23,6 +23,14 @@ ARCH=$(uname -m)
 
 call_cmake() {
 	SRC_DIR=$1
+
+	# Make sure we've been passed a full checkout of libs,
+	# (on which we're forced to be running cmake to configure)
+	# as opposed to an already-configured source package
+	if [[ ! -f ${SRC_DIR}/CMakeLists.txt ]]; then
+		return 1
+	fi
+
 	PROBE_NAME_PARAM=PROBE_NAME
 	PROBE_VERSION_PARAM=PROBE_VERSION
 	PROBE_DEVICE_NAME_PARAM=PROBE_DEVICE_NAME
@@ -46,18 +54,29 @@ build_kmod() {
 	mkdir -p /build/sysdig
 	cd /build/sysdig
 
-	call_cmake /code/sysdig-rw
-	make driver
-	strip -g driver/$PROBE_NAME.ko
+	# Glue code for backwards compatibility with a plain libs/ checkout
+	if call_cmake /code/sysdig-rw; then
+		# cmake was successful, we'll run 'make' from within the
+		# /build/sysdig directory where cmake copied all files for us
+		BUILD_DIR=/build/sysdig/driver
+		make -C $BUILD_DIR driver
+	else
+		# cmake failed, so we're probably dealing with a package file
+		# and we can therefore run make from the source tree
+		# (without the driver/ prefix)
+		BUILD_DIR=/code/sysdig-rw
+		make -C $BUILD_DIR all
+	fi
+	strip -g $BUILD_DIR/$PROBE_NAME.ko
 
-	KO_VERSION=$(/sbin/modinfo driver/$PROBE_NAME.ko | grep vermagic | tr -s " " | cut -d " " -f 2)
+	KO_VERSION=$(/sbin/modinfo $BUILD_DIR/$PROBE_NAME.ko | grep vermagic | tr -s " " | cut -d " " -f 2)
 	if [ "$KO_VERSION" != "$KERNEL_RELEASE" ]; then
 		echo "Corrupted probe, KO_VERSION " $KO_VERSION ", KERNEL_RELEASE " $KERNEL_RELEASE
 		exit 1
 	fi
 
-	cp driver/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
-	cp driver/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko
+	cp $BUILD_DIR/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.ko
+	cp $BUILD_DIR/$PROBE_NAME.ko $OUTPUT/$PROBE_NAME-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH_ORIG.ko
 }
 
 
@@ -69,9 +88,16 @@ build_bpf() {
 		echo "Building eBPF probe $PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o"
 		mkdir -p /build/sysdig
 		cd /build/sysdig
-		call_cmake /code/sysdig-rw
-		make -C /code/sysdig-rw/driver/bpf clean all
-		cp /code/sysdig-rw/driver/bpf/probe.o $OUTPUT/$PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o
+
+		# for the eBPF probe, cmake will only configure the files we need
+		# but we'll end up running make from the source tree anyway
+		if call_cmake /code/sysdig-rw; then
+			BUILD_DIR=/code/sysdig-rw/driver
+		else
+			BUILD_DIR=/code/sysdig-rw
+		fi
+		make -C $BUILD_DIR/bpf clean all
+		cp $BUILD_DIR/bpf/probe.o $OUTPUT/$PROBE_NAME-bpf-$PROBE_VERSION-$ARCH-$KERNEL_RELEASE-$HASH.o
 	fi
 }
 


### PR DESCRIPTION
The current procedure is based on the assumption of having a full checkout of agent-libs.
However, the source code (for both kernel module and eBPF probe) is also available as the draios-agent-kmodule.tar.gz file where all parameters are already populated.
Enable that scenario while also retaining compatibility with the existing one.
Notice the unavoidable tweaks since there is no longer a driver/ directory available.