### PR TITLE
[SMAGENT-5086] replace download-ib01.fedoraproject.org with mirrors.rit.edu

### DIFF
--- a/probe_builder/kernel_crawler/fedora.py
+++ b/probe_builder/kernel_crawler/fedora.py
@@ -13,10 +13,10 @@ class FedoraMirror(repo.Distro):
     def get_mirrors(self, crawler_filter):
         mirrors = [
             # Obtained by picking one from https://mirrors.fedoraproject.org/metalink?repo=fedora-37&arch=x86_64
-            ### -> http://download-ib01.fedoraproject.org/pub/fedora/linux/releases/37/Everything/x86_64/os/repodata/repomd.xml
-            rpm.RpmMirror('http://download-ib01.fedoraproject.org/pub/fedora/linux/releases/', 'Everything/{}/os/'.format(crawler_filter.machine), repo_filter),
+            ### -> http://mirrors.rit.edu/fedora/fedora/linux/releases/37/Everything/x86_64/os/repodata/repomd.xml
+            rpm.RpmMirror('http://mirrors.rit.edu/fedora/fedora/linux/releases/', 'Everything/{}/os/'.format(crawler_filter.machine), repo_filter),
             # https://mirrors.fedoraproject.org/metalink?repo=updates-released-f37&arch=x86_64
-            ### -> http://download-ib01.fedoraproject.org/pub/fedora/linux/updates/37/Everything/x86_64/repodata/repomd.xml
-            rpm.RpmMirror('http://download-ib01.fedoraproject.org/pub/fedora/linux/updates/', 'Everything/{}/'.format(crawler_filter.machine), repo_filter),
+            ### -> http://mirrors.rit.edu/fedora/fedora/linux/updates/37/Everything/x86_64/repodata/repomd.xml
+            rpm.RpmMirror('http://mirrors.rit.edu/fedora/fedora/linux/updates/', 'Everything/{}/'.format(crawler_filter.machine), repo_filter),
         ]
         return mirrors


### PR DESCRIPTION
Recent fedora crawls have been failing due to

requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: http://download-ib01.fedoraproject.org/pub/fedora/linux/releases/

Suggesting that mirror download-ib01.fedoraproject.net might have been taken down.

Until we implament a proper mechanism with metaliknk, replace it with another one, like mirrors.rit.edu.