### PR TITLE
ubuntu: pin gcc to 11.2 and 11.3 on jammy builders

### DIFF
--- a/Dockerfile.ubuntu-gcc11.3-bpf
+++ b/Dockerfile.ubuntu-gcc11.3-bpf
@@ -1,7 +1,7 @@
 FROM ubuntu:jammy
 
 RUN for pkg in g++-11 gcc-11 cpp-11 gcc-11-base libgcc-11-dev libasan6 libtsan0 libobjc-11-dev libstdc++-11-dev; do \
-	echo "Package: $pkg\nPin: version 11.2.*\nPin-Priority: 900\n" \
+	echo "Package: $pkg\nPin: version 11.3.*\nPin-Priority: 900\n" \
 	>> /etc/apt/preferences.d/pin-gcc; done
 RUN \
 	apt-get update && \


### PR DESCRIPTION
gcc-11 11.3 is the required compiler for 6.2.0-25
(backported to jammy), but we currently only
have a builder marked for gcc 11.2.
As a matter of fact, this results in the builder
for gcc12.2 being picked as the next best choice,
which fails because there is no gcc-11 binary.

As a matter of fact, after the release of 22.04.2, gcc-11 will resolve to 11.3.0, which breaks the
promise of having a certain gcc version in the
dockerfile name.

So pin the gcc-11 version so that we can get two
separate builders for gcc 11.2 and 11.3,
whose version is guaranteed to be honored
even in case of future updates.