### PR TITLE
Update Debian Jessie and Stretch

### DIFF
--- a/Dockerfile.debian-gcc4.9
+++ b/Dockerfile.debian-gcc4.9
@@ -1,6 +1,9 @@
 FROM debian/eol:jessie
 
-RUN apt-get update && apt-get -y --no-install-recommends install \
+RUN sed -i -e 's/deb.debian.org/archive.debian.org\/debian-archive/g' /etc/apt/sources.list && \
+    sed -i -e 's/security.debian.org/archive.debian.org\/debian-archive/g' /etc/apt/sources.list && \
+    sed -i '/jessie-updates/d' /etc/apt/sources.list && \
+    apt-get update && apt-get -y --no-install-recommends install \
 	cmake \
 	g++ \
 	git \

--- a/Dockerfile.debian-gcc6.3-bpf
+++ b/Dockerfile.debian-gcc6.3-bpf
@@ -1,6 +1,9 @@
 FROM debian:stretch
 
-RUN apt-get update && apt-get -y --no-install-recommends install \
+RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list && \
+    sed -i -e 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list && \
+    sed -i '/stretch-updates/d' /etc/apt/sources.list && \
+    apt-get update && apt-get -y --no-install-recommends install \
 	cmake \
 	g++ \
 	git \


### PR DESCRIPTION
Debian Jessie and Stretch repositories (main, security and updates) are not available anymore, therefore the build of those two containers fails when following step 3 of these instructions:
https://docs.sysdig.com/en/docs/installation/on-premises/airgapped-installation/#prepare-the-sysdig-probe-builder-images

This PR will switch `deb.debian.org` and `security.debian.org` to `archive.debian.org` and removes `<distro-name>-updates` from repo list