### PR TITLE
[SMAGENT-5267] Fix prebuilt builders for air-gapped environments

### DIFF
--- a/main-builder-entrypoint.sh
+++ b/main-builder-entrypoint.sh
@@ -77,10 +77,10 @@ build_probes()
 	probe_builder ${DEBUG_PREFIX} build -s /sysdig -b "$BUILDER_IMAGE_PREFIX" "$@" /kernels/*
 }
 
-prepare_builders()
+prebuild_builders()
 {
 	check_docker_socket
-	for i in Dockerfile.* ; do docker build -t ${BUILDER_IMAGE_PREFIX}sysdig-probe-builder:${i#Dockerfile.} -f $i . ; done
+	probe_builder ${DEBUG_PREFIX} prebuild -b "$BUILDER_IMAGE_PREFIX" "$@"
 }
 
 download_from_artifactory()
@@ -115,7 +115,7 @@ do
 			DEBUG_PREFIX="--debug"
 			;;
 		P)
-			OP=prepare
+			OP=prebuild
 			;;
 		\?)
 			echo "Invalid option $OPTARG" >&2
@@ -143,8 +143,8 @@ case "${OP:-}" in
 	crawl)
 		crawl "$@"
 		;;
-	prepare)
-		prepare_builders
+	prebuild)
+		prebuild_builders "$@"
 		;;
 	*)
 		usage

--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -107,6 +107,17 @@ def cli(debug):
 
 @click.command()
 @click.option('-b', '--builder-image-prefix', default='')
+@click.option('-m', '--machine', default=os.uname().machine)
+def prebuild(builder_image_prefix, machine):
+    builder_source = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    arch = kernel_crawler.repo.machine2arch(machine)
+    all_dockerfiles_and_tags = choose_builder.all_dockerfiles(builder_source=builder_source)
+    context_dir = os.getcwd()
+    for dockerfile, dockerfile_tag in all_dockerfiles_and_tags:
+        builder_image.prebuild(context_dir, builder_image_prefix, dockerfile, dockerfile_tag, arch)
+
+@click.command()
+@click.option('-b', '--builder-image-prefix', default='')
 @click.option('-d', '--download-concurrency', type=click.INT, default=1)
 @click.option('-j', '--jobs', type=click.INT, default=len(os.sched_getaffinity(0)))
 @click.option('-k', '--kernel-type', type=click.Choice(sorted(CLI_DISTROS.keys())))
@@ -208,6 +219,7 @@ def crawl(distro, distro_filter='', kernel_filter=''):
             print(' {}'.format(pkg))
 
 
+cli.add_command(prebuild, 'prebuild')
 cli.add_command(build, 'build')
 cli.add_command(crawl, 'crawl')
 

--- a/probe_builder/builder/builder_image.py
+++ b/probe_builder/builder/builder_image.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 builders = {}
 builders_lock = threading.Lock()
 
+def prebuild(context_dir, image_prefix, dockerfile, dockerfile_tag, arch):
+    image_name = '{}sysdig-probe-builder:{}'.format(image_prefix, dockerfile_tag)
+    docker.build(arch, image_name, dockerfile, context_dir)
+
 def build(workspace, dockerfile, dockerfile_tag):
     with builders_lock:
         k = (dockerfile, dockerfile_tag)

--- a/probe_builder/builder/choose_builder.py
+++ b/probe_builder/builder/choose_builder.py
@@ -50,6 +50,11 @@ def choose_distro_dockerfile(builder_source, _builder_distro, kernel_dir):
         fn = m[0]
         return fn, distro_tag, fn.endswith("-bpf")
 
+def all_dockerfiles(builder_source):
+    prefix = "Dockerfile."
+    return [
+        (f, f.replace(prefix,'')) for f in os.listdir(builder_source) if f.startswith(prefix)
+    ]
 
 def get_kernel_gcc_version(kernel_dir):
     # Try to find the gcc version used to build this particular kernel


### PR DESCRIPTION
When introducing support for cross-architectural builds, we had to add a suffix specifying the architecture (e.g. ubuntu-gcc11.2-bpf-amd64) in order to tell the multiple builders apart.

The step that prebuilds all the builders to be imported into the air-gapped host (-P) is currently implemented within the bash entrypoint and does not add that suffix, thereby invalidating the whole procedure.

So defer the actual prebuilding to a newly-introduced 'prebuild' command of the python code, so that the whole naming logic is encapsulated within the same code for both producer (prebuild) and consumer (actual building).