### PR TITLE
ubuntu: add a jammy builder with gcc 11.4

### DIFF
--- a/Dockerfile.ubuntu-gcc11.4-bpf
+++ b/Dockerfile.ubuntu-gcc11.4-bpf
@@ -1,0 +1,34 @@
+FROM ubuntu:jammy
+
+RUN for pkg in g++-11 gcc-11 cpp-11 gcc-11-base libgcc-11-dev libasan6 libtsan0 libobjc-11-dev libstdc++-11-dev; do \
+	echo "Package: $pkg\nPin: version 11.4.*\nPin-Priority: 900\n" \
+	>> /etc/apt/preferences.d/pin-gcc; done
+RUN \
+	apt-get update && \
+	apt-get -y --no-install-recommends install \
+		cmake \
+		g++-11 \
+		git \
+		kmod \
+		libc6-dev \
+		libelf-dev \
+		make \
+		pkg-config \
+		clang-14 \
+		llvm-14 \
+		&& apt-get clean
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11
+
+# Enforce usage of clang 14, since clang 15 seems to
+# raise a lot of verifier issues
+# Notice how at the time of writing clang would just
+# link to clang-14 (as opposed to kinetic which has
+# apparently migrated to clang-15)
+ENV CLANG clang-14
+ENV LLC llc-14
+
+ADD builder-entrypoint.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]
+


### PR DESCRIPTION
gcc-11 11.4 is the required compiler for 6.2.0-1009 (backported to jammy), but we currently only have
builders marked for gcc 11.2 and 11.3 (see #102).

As it was previously noted, this results in the builder for gcc12.2 being picked as the next best choice,
which fails because there is no gcc-11 binary.

So along the line of what was already done, add a
dedicated builder for gcc11.4.