### PR TITLE
ubuntu: add a mantic builder with gcc13.2

### DIFF
--- a/Dockerfile.ubuntu-gcc13.2-bpf
+++ b/Dockerfile.ubuntu-gcc13.2-bpf
@@ -1,0 +1,26 @@
+FROM ubuntu:mantic
+
+RUN echo 'deb http://archive.ubuntu.com/ubuntu/ mantic-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/ubuntu-proposed.list && \
+	apt-get update && \
+	apt-get -y --no-install-recommends install \
+		cmake \
+		g++ \
+		git \
+		kmod \
+		libc6-dev \
+		libelf-dev \
+		make \
+		pkg-config \
+		clang-14 \
+		llvm-14 \
+		&& apt-get clean
+
+# Enforce usage of clang 14, since clang 15 seems to
+# raise a lot of verifier issues
+ENV CLANG clang-14
+ENV LLC llc-14
+
+ADD builder-entrypoint.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]
+


### PR DESCRIPTION
gcc-13 13.2.0 is the required compiler for 6.5.0
ubuntu kernels.
Add it through mantic 23.10 where it's natively supported (and not a backport to e.g. lunar 23.04).