### PR TITLE
debian: fix support for 6.4/6.5 kernels

### DIFF
--- a/Dockerfile.debian-gcc13.2-bpf
+++ b/Dockerfile.debian-gcc13.2-bpf
@@ -1,0 +1,19 @@
+FROM debian:trixie
+
+RUN apt-get update && apt-get -y --no-install-recommends install \
+	cmake \
+	g++-13 \
+	git \
+	kmod \
+	libc6-dev \
+	libelf-dev \
+	make \
+	pkg-config \
+	clang \
+	llvm \
+	&& apt-get clean
+
+ADD builder-entrypoint.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]
+


### PR DESCRIPTION
Recent kernels have started naming their linux-kbuild packages as linux-kbuild-6.5.0-0 as opposed to linux-6.3, thereby breaking our batching logic.
Add support for both kinds of package namings
(minor-truncated vs. full kernel version).

Also, add the missing debian builder with gcc 13.2 (based on the upcoming trixie).