### PR TITLE
ubuntu: add gcc12.3 and restore gcc12.2

### DIFF
--- a/Dockerfile.ubuntu-gcc12.3-bpf
+++ b/Dockerfile.ubuntu-gcc12.3-bpf
@@ -1,7 +1,7 @@
-FROM ubuntu:lunar
+FROM ubuntu:jammy
 
 RUN for pkg in g++-12 gcc-12 cpp-12 gcc-12-base libgcc-12-dev libasan6 libtsan0 libobjc-12-dev libstdc++-12-dev; do \
-	echo "Package: $pkg\nPin: version 12.2.*\nPin-Priority: 900\n" \
+	echo "Package: $pkg\nPin: version 12.3.*\nPin-Priority: 900\n" \
 	>> /etc/apt/preferences.d/pin-gcc; done
 RUN \
 	apt-get update && \
@@ -22,6 +22,9 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12
 
 # Enforce usage of clang 14, since clang 15 seems to
 # raise a lot of verifier issues
+# Notice how at the time of writing clang would just
+# link to clang-14 (as opposed to kinetic which has
+# apparently migrated to clang-15)
 ENV CLANG clang-14
 ENV LLC llc-14
 


### PR DESCRIPTION
- gcc12.3 is available on both lunar 23.04 and jammy 22.04 LTS. Since lunar will reach EOL at the end of 2023, prefer Jammy which has a much longer timespan (December 2026).

- gcc12.2 currently comes from kinetic 22.10 which reached EOL in July. Therefore new builds are broken. Unfortunately it is not available on jammy 22.04 LTS though. So take it from lunar (currently defaulting to gcc12.3) by pinning. The alternative would be to drop it entirely in favor of gcc12.3.