### PR TITLE
feat: introduce drel (distro release)

### DIFF
--- a/probe_builder/builder/distro/centos.py
+++ b/probe_builder/builder/distro/centos.py
@@ -15,10 +15,9 @@ class CentosBuilder(DistroBuilder):
 
     def unpack_kernels(self, workspace, distro, kernels):
         kernel_dirs = list()
-
-        for release, rpms in kernels.items():
-            target = workspace.subdir('build', distro, release)
-            kernel_dirs.append((release, target))
+        for (drel, krel), rpms in kernels.items():
+            target = workspace.subdir('build', distro, krel)
+            kernel_dirs.append(((drel,krel), target))
 
             for rpm in rpms:
                 rpm_basename = os.path.basename(rpm)

--- a/probe_builder/builder/distro/photonos.py
+++ b/probe_builder/builder/distro/photonos.py
@@ -22,8 +22,8 @@ class PhotonosBuilder(CentosBuilder):
         )
         # make up a new list with stripped release version
         renamed = {}
-        for release, urls in orig.items():
-            renamed[self.strip_release(release)] = urls
+        for (drel, krel), urls in orig.items():
+            renamed[(drel,self.strip_release(krel))] = urls
         return renamed
 
     def get_kernel_dir(self, workspace, release, target):

--- a/probe_builder/builder/distro/ubuntu.py
+++ b/probe_builder/builder/distro/ubuntu.py
@@ -20,6 +20,7 @@ class UbuntuBuilder(DistroBuilder):
     def crawl(self, workspace, distro, crawler_distro, download_config=None, crawler_filter=EMPTY_FILTER):
         crawled_dict = super().crawl(workspace=workspace, distro=distro, crawler_distro=crawler_distro, download_config=download_config, crawler_filter=crawler_filter)
         kernels = []
+        logger.debug("crawled_dict={}".format(crawled_dict))
         # batch packages according to package version, e.g. '5.15.0-1001/1' as returned by the crawler
         # (which is the package version of the main 'linux-headers-5.15.0-1001-gke_5.15.0-1001.1_amd64.deb')
         # each of those versions may yield one or more releases e.g. '5.15.0-1001-gke'
@@ -172,11 +173,12 @@ class UbuntuBuilder(DistroBuilder):
         #]
 
         for version, release_ids in version_to_releases.items():
+            drel, kver = version
             for release_id in release_ids:
                 release_files = releases[(release_id, version)]
                 # add all the shared files that end up in the same directory
                 release_files.extend(version_files.get(version, []))
-                kernels.append((release_id, release_files))
+                kernels.append(((drel, release_id), release_files))
 
         logger.debug("kernels=\n{}".format(pp.pformat(kernels)))
         return kernels

--- a/probe_builder/kernel_crawler/amazonlinux.py
+++ b/probe_builder/kernel_crawler/amazonlinux.py
@@ -18,7 +18,7 @@ def get_al_repo(repo_root, repo_release):
     return make_string(resp.splitlines()[0]).rstrip('/') + '/'
 
 
-class AmazonLinux1Mirror(repo.Distro):
+class AmazonLinux1Mirror(repo.Mirror):
     AL1_REPOS = [
         'latest/updates',
         'latest/main',
@@ -39,7 +39,7 @@ class AmazonLinux1Mirror(repo.Distro):
         return [rpm.RpmRepository(url) for url in sorted(repo_urls)]
 
 
-class AmazonLinux2Mirror(repo.Distro):
+class AmazonLinux2Mirror(repo.Mirror):
     AL2_REPOS = [
         'core/2.0',
         'core/latest',
@@ -55,7 +55,7 @@ class AmazonLinux2Mirror(repo.Distro):
                 repo_urls.add(get_al_repo("http://amazonlinux.us-east-1.amazonaws.com/2/", r + '/' + crawler_filter.machine))
         return [rpm.RpmRepository(url) for url in sorted(repo_urls)]
 
-class AmazonLinux2022Mirror(repo.Distro):
+class AmazonLinux2022Mirror(repo.Mirror):
 
     # This was obtained by running
     # docker run -it --rm amazonlinux:2022 python3 -c 'import dnf, json; db = dnf.dnf.Base(); print(json.dumps(db.conf.substitutions, indent=2))'

--- a/probe_builder/kernel_crawler/debian.py
+++ b/probe_builder/kernel_crawler/debian.py
@@ -20,18 +20,22 @@ class DebianMirror(repo.Distro):
     # can be resolved (i.e. build_package_tree) across multiple repositories.
     # This is namely required for the linux-kbuild package, which is typically
     # hosted on a different repository compared to the kernel packages
+    # In particular, we get all DebRepository'es for a given distro release
+    # (e.g. for bookworm we'll have bookwork, bookworm-backports, bookworm-proposed-updates etc...)
+    # and resolve dependencies across those.
+    # At the end, we return a dictionary: { (drel, krel) : [...] }
     def get_package_tree(self, crawler_filter):
-        all_packages = {}
-        all_kernel_packages = []
         packages = {}
-        repos = self.list_repos(crawler_filter)
-        with click.progressbar(repos, label='Listing packages', file=sys.stderr, item_show_func=repo.to_s) as repos:
-            for repository in repos:
-                repo_packages = repository.get_raw_package_db()
-                all_packages.update(repo_packages)
-                kernel_packages = repository.get_package_list(repo_packages, crawler_filter.kernel_filter)
-                all_kernel_packages.extend(kernel_packages)
-
-        for release, dependencies in deb.DebRepository.build_package_tree(all_packages, all_kernel_packages).items():
-            packages.setdefault(release, set()).update(dependencies)
+        drel_repos = self.list_drel_repos(crawler_filter)
+        with click.progressbar(drel_repos.items(), label='Listing packages', file=sys.stderr, item_show_func=repo.to_s) as drel_repos_items:
+            for drel, repos in drel_repos_items:
+                all_packages = {}
+                all_kernel_packages = []
+                for repository in repos:
+                    repo_packages = repository.get_raw_package_db()
+                    all_packages.update(repo_packages)
+                    kernel_packages = repository.get_package_list(repo_packages, crawler_filter.kernel_filter)
+                    all_kernel_packages.extend(kernel_packages)
+                for krel, dependencies in deb.DebRepository.build_package_tree(all_packages, all_kernel_packages).items():
+                    packages.setdefault((drel, krel), set()).update(dependencies)
         return packages

--- a/probe_builder/kernel_crawler/oracle.py
+++ b/probe_builder/kernel_crawler/oracle.py
@@ -11,7 +11,7 @@ class OracleRepository(rpm.RpmRepository):
         return '''(name IN ('kernel', 'kernel-devel', 'kernel-uek', 'kernel-uek-devel') AND arch IN ('x86_64', 'aarch64'))'''
 
 
-class Oracle6Mirror(repo.Distro):
+class Oracle6Mirror(repo.Mirror):
     OL6_REPOS = [
         'http://yum.oracle.com/repo/OracleLinux/OL6/latest/{}/',
         'http://yum.oracle.com/repo/OracleLinux/OL6/MODRHCK/{}/',
@@ -24,7 +24,7 @@ class Oracle6Mirror(repo.Distro):
         return [OracleRepository(url.format(crawler_filter.machine)) for url in self.OL6_REPOS]
 
 
-class Oracle7Mirror(repo.Distro):
+class Oracle7Mirror(repo.Mirror):
     OL7_REPOS = [
         'http://yum.oracle.com/repo/OracleLinux/OL7/latest/{}/',
         'http://yum.oracle.com/repo/OracleLinux/OL7/MODRHCK/{}/',
@@ -38,7 +38,7 @@ class Oracle7Mirror(repo.Distro):
         return [OracleRepository(url.format(crawler_filter.machine)) for url in self.OL7_REPOS]
 
 
-class Oracle8Mirror(repo.Distro):
+class Oracle8Mirror(repo.Mirror):
     OL8_REPOS = [
         'http://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/{}/',
         'http://yum.oracle.com/repo/OracleLinux/OL8/UEKR6/{}/',
@@ -49,7 +49,7 @@ class Oracle8Mirror(repo.Distro):
         return [OracleRepository(url.format(crawler_filter.machine)) for url in self.OL8_REPOS]
 
 
-class Oracle9Mirror(repo.Distro):
+class Oracle9Mirror(repo.Mirror):
     OL9_REPOS = [
         'http://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/{}/',
         'http://yum.oracle.com/repo/OracleLinux/OL9/appstream/{}/',

--- a/probe_builder/kernel_crawler/photon_os.py
+++ b/probe_builder/kernel_crawler/photon_os.py
@@ -19,17 +19,19 @@ class PhotonOsRepository(rpm.RpmRepository):
         '''
 
 
-class PhotonOsMirror(repo.Distro):
-    PHOTON_OS_VERSIONS = [
-        ('3.0', '_release'),
-        ('3.0', '_updates'),
-        ('4.0', ''),
-        ('4.0', '_release'),
-        ('4.0', '_updates'),
-    ]
+class PhotonOsMirror(repo.Mirror):
+    PHOTON_OS_VERSIONS = {
+        '3.0': ['_release', '_updates'],
+        '4.0': ['', '_release', '_updates'],
+    }
 
-    def list_repos(self, crawler_filter):
-        return [
-            PhotonOsRepository('https://packages.vmware.com/photon/{v}/photon{r}_{v}_{m}/'.format(
-                v=version, r=repo_tag, m=crawler_filter.machine))
-            for version, repo_tag in self.PHOTON_OS_VERSIONS]
+    def list_drel_repos(self, crawler_filter):
+        return {
+            version: [
+                PhotonOsRepository('https://packages.vmware.com/photon/{v}/photon{r}_{v}_{m}/'.format(
+                    v=version, r=repo_tag, m=crawler_filter.machine))
+                for repo_tag in repo_tags
+            ]
+            for version, repo_tags in self.PHOTON_OS_VERSIONS.items()
+            if version.startswith(crawler_filter.distro_filter)
+        }

--- a/probe_builder/kernel_crawler/repo.py
+++ b/probe_builder/kernel_crawler/repo.py
@@ -3,8 +3,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from collections import namedtuple
 import click
+import logging
 import os
 import sys
+
+logger = logging.getLogger(__name__)
 
 def machine2arch(mach):
     mach2arch = {
@@ -16,6 +19,15 @@ def machine2arch(mach):
 CrawlerFilter = namedtuple("CrawlerFilter", ["machine", "arch", "distro_filter", "kernel_filter"], defaults=[os.uname().machine, machine2arch(os.uname().machine), "", ""])
 
 EMPTY_FILTER=CrawlerFilter()
+
+# A repo.Repository is a collection of packages, implmemented through .get_package_tree()
+#
+# A repo.Mirror is a collection of repositories, returned by .list_repos()
+#  TODO: should the Mirror be a subclass of Repository since it also implements get_package_tree?
+
+# A repo.Distro is a collection of mirrors (and a subclass of mirror, so to be a drop-in replacement),
+#   returned by .get_mirrors()
+#   for which the list of repositories is just the union of all the repositories of each mirror
 
 class Repository(object):
     def get_package_tree(self, crawler_filter):
@@ -36,17 +48,25 @@ class Mirror(object):
     def list_repos(self, crawler_filter):
         raise NotImplementedError
 
+    # This is a compatibility layer for Mirror(s)/Distro(s) which
+    # do not implement list_drel_repos
+    def list_drel_repos(self, crawler_filter):
+        return { "": self.list_repos(crawler_filter) }
+
+    # The package tree of a mirror is simply the union of all the package trees of repos composing it
     def get_package_tree(self, crawler_filter):
         packages = {}
-        repos = self.list_repos(crawler_filter)
-        with click.progressbar(length=len(repos), label='Listing packages', file=sys.stderr, item_show_func=to_s) as pbar:
+        drel_repos = self.list_drel_repos(crawler_filter)
+        with click.progressbar(length=len(drel_repos), label='Listing packages', file=sys.stderr, item_show_func=to_s) as pbar:
             with ThreadPoolExecutor(max_workers=8) as executor:
-                futures = { executor.submit(repo.get_package_tree, crawler_filter): str(repo) for repo in repos }
+                futures = { executor.submit(repo.get_package_tree, crawler_filter): (drel, str(repo)) for (drel, repos) in drel_repos.items() for repo in repos }
                 for future in as_completed(futures):
-                    repo = futures[future]
-                    for release, dependencies in future.result().items():
-                        packages.setdefault(release, set()).update(dependencies)
+                    drel, repo = futures[future]
+                    for krel, dependencies in future.result().items():
+                        packages.setdefault((drel, krel), set()).update(dependencies)
                     pbar.update(1, repo)  # Increments counter
+
+        logger.info("Mirror.get_package_tree() returned packages with the following keys (packages omitted): {}".format(packages.keys()))
         return packages
 
 
@@ -55,10 +75,18 @@ class Distro(Mirror):
     def get_mirrors(self, crawler_filter):
         raise NotImplementedError
 
-    def list_repos(self, crawler_filter):
-        repos = []
+    # A distro (i.e. a collection of mirrors) will provide a set of repos
+    # by composing (extending) all repos of each mirror, grouped by drel (distro release),
+    # In other words, all kinetic* repos from each mirror will end up together
+    def list_drel_repos(self, crawler_filter):
+        # Merge the repositories obtained across the mirrors
+        drel_repos = {}
         with click.progressbar(
-                self.get_mirrors(crawler_filter), label='Checking repositories', file=sys.stderr, item_show_func=to_s) as mirrors:
+                self.get_mirrors(crawler_filter), label='Checking mirrors of the distro', file=sys.stderr, item_show_func=to_s) as mirrors:
             for mirror in mirrors:
-                repos.extend(mirror.list_repos(crawler_filter))
-        return repos
+                _drel_repos = mirror.list_drel_repos(crawler_filter)
+                for drel, repos in _drel_repos.items():
+                    logger.info("drel '{}' has repos {} ".format(drel, repos))
+                    drel_repos.setdefault(drel, []).extend(repos)
+
+        return drel_repos

--- a/probe_builder/kernel_crawler/repo.py
+++ b/probe_builder/kernel_crawler/repo.py
@@ -20,7 +20,7 @@ CrawlerFilter = namedtuple("CrawlerFilter", ["machine", "arch", "distro_filter",
 
 EMPTY_FILTER=CrawlerFilter()
 
-# A repo.Repository is a collection of packages, implmemented through .get_package_tree()
+# A repo.Repository is a collection of packages, implemented through .get_package_tree()
 #
 # A repo.Mirror is a collection of repositories, returned by .list_repos()
 #  TODO: should the Mirror be a subclass of Repository since it also implements get_package_tree?


### PR DESCRIPTION
This PR changes the logic used by the crawler and then propagated to the builder so that the "release" (previously just the kernel release) is now a tuple composed of two parts:
- drel (distro release, e.g. 'kinetic')
- kernel (kernel release, same as before)

This brings in two significant advantages:
1. Fixes the issue with backported debian kernels, in that we only resolved packages across repositories within the same distro release (e.g. buster), see SMAGENT-5278
2. Each individual kernel build has more context (i.e. the distro release where that kernel was found). This way, when trying to reproduce that kernel build, we can also specify e.g. `-R buster` to only crawl packages within that distro release, reducing overall execution time. It also gives more context as to what image would be required to reproduce a full testing environment for that kernel.

This is done through the following changes:
- introduce Mirror.get_drel_repos() as a replacement for list_repos(), which instead of returning a bare list of Repository, will return a dict where the key is the drel.
- Particularly, implement .get_drel_repos() for DebMirror (base class for both Ubuntu and Debian) so that the (deb)dists (e.g. 'kinetic', 'kinetic-updates', ...) are all grouped under the corresponding distro release 'kinetic'.
- ditto for RpmMirror
- update Mirror.get_package_tree() so to leverage the new classification (list_drel_repos()) and provide the tuple as the key
- change the logic within DebianMirror.get_package_tree() so to adapt for the new classification returned by list_dreal_repos() AND resolve dependencies among the DebRepository-es belonging to the same drelease (previously it was a global heap of ALL repositories). NOTE: this will resolve SMAGENT-5278 i.e. the issue where backported 6.1.0 kernels will use the (overall) newest linux-kbuild package which is NOT compatibile with older Debian releases.
- update {CentosBuilder,UbuntuBuilder,DebianBuilder}.unpack_kernels() so to expect a tuple as the key of the input 'kernels' parameter
- redefine single-mirror distros (i.e. AmazonLinux, Oracle, PhotonOs) so to be a subclass of repo.Mirror instead of repo.Distro. This way we don't fall for the trap of Distro.list_drel_repos() calling self.get_mirrors() which is indeed (and rightfully so) not implemented.
- refactor the code of probe_builder.build() so to print an extra column (i.e. the distro release)