### PR TITLE
fix(ubuntu): add g++ symlink for pinned gcc releases

### DIFF
--- a/Dockerfile.ubuntu-gcc11.2-bpf
+++ b/Dockerfile.ubuntu-gcc11.2-bpf
@@ -18,7 +18,8 @@ RUN \
 		llvm-14 \
 		&& apt-get clean
 
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11
 
 # Enforce usage of clang 14, since clang 15 seems to
 # raise a lot of verifier issues

--- a/Dockerfile.ubuntu-gcc11.3-bpf
+++ b/Dockerfile.ubuntu-gcc11.3-bpf
@@ -18,7 +18,8 @@ RUN \
 		llvm-14 \
 		&& apt-get clean
 
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11
 
 # Enforce usage of clang 14, since clang 15 seems to
 # raise a lot of verifier issues

--- a/Dockerfile.ubuntu-gcc11.4-bpf
+++ b/Dockerfile.ubuntu-gcc11.4-bpf
@@ -18,7 +18,8 @@ RUN \
 		llvm-14 \
 		&& apt-get clean
 
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11
 
 # Enforce usage of clang 14, since clang 15 seems to
 # raise a lot of verifier issues

--- a/Dockerfile.ubuntu-gcc12.2-bpf
+++ b/Dockerfile.ubuntu-gcc12.2-bpf
@@ -18,7 +18,8 @@ RUN \
 		llvm-14 \
 		&& apt-get clean
 
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12
 
 # Enforce usage of clang 14, since clang 15 seems to
 # raise a lot of verifier issues

--- a/Dockerfile.ubuntu-gcc12.3-bpf
+++ b/Dockerfile.ubuntu-gcc12.3-bpf
@@ -18,7 +18,8 @@ RUN \
 		llvm-14 \
 		&& apt-get clean
 
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12
 
 # Enforce usage of clang 14, since clang 15 seems to
 # raise a lot of verifier issues


### PR DESCRIPTION
Many ubuntu builds will currently fail with the following error when trying to build off a driver checkout:

No CMAKE_CXX_COMPILER could be found.

Notice this only applies to older releases building off the bare code from the git repo, since they require cmake to produce the makefile, which expects a default C++ compiler to be available.
Newer releases building off the packaged (preprocessed) source code do not expose this behavior.