### PR TITLE
fix(ignorelist): refine broke agents for kernel 6.3

### DIFF
--- a/agent_ignorelist.yaml
+++ b/agent_ignorelist.yaml
@@ -28,8 +28,15 @@ ignorelist:
     matcher: generic
     skip_if: "{{ (major|int > 6) or (major|int == 6 and minor|int >= 2) }}"
 
-  - description: "kernel 6.4: argument 1 of 'class_create' from incompatible pointer type"
-    probe_versions: [ 12.12.0, 12.13.0, 12.14.0, 12.14.1 ]
+  - description: "kernel 6.3: argument 1 of 'class_create' from incompatible pointer type"
+    probe_versions: [ 12.12.0, 12.13.0, 12.14.0 ]
+    probe_kinds: [ kmod, legacy_ebpf ]
+    matcher: generic
+    skip_if: "{{ (major|int > 6) or (major|int == 6 and minor|int >= 3) }}"
+
+# 12.14.1 fixed the build for bpf but not for kmod
+  - description: "kernel 6.3: argument 1 of 'class_create' from incompatible pointer type"
+    probe_versions: [ 12.14.1 ]
     probe_kinds: [ kmod ]
     matcher: generic
-    skip_if: "{{ (major|int > 6) or (major|int == 6 and minor|int >= 4) }}"
+    skip_if: "{{ (major|int > 6) or (major|int == 6 and minor|int >= 3) }}"


### PR DESCRIPTION
- actual first broken kernel was 6.3 not 6.4
- turns out ebpf was also affected, but got fixed with 12.14.1 (as opposed to kmod which only got fixed with 12.15.0)