### PR TITLE
fix(ubuntu,fedora): agent driver broken on kernel 6.6

### DIFF
--- a/agent_ignorelist.yaml
+++ b/agent_ignorelist.yaml
@@ -4,6 +4,12 @@ matchers:
   generic: ^(?P<major>[0-9])\.(?P<minor>[0-9]+)\..*
 
 ignorelist:
+  - description: "[SMAGENT-6088] Kernel 6.6 on agent <= 12.17.1"
+    probe_versions: [ 12.15.0, 12.16.0, 12.16.1, 12.16.2, 12.16.3, 12.17.0, 12.17.1 ]
+    probe_kinds: [ kmod, legacy_ebpf ]
+    matcher: generic
+    skip_if: "{{ (major|int > 6) or (major|int == 6 and minor|int >= 6) }}"
+
   - description: "[SMAGENT-5378] RHEL8.9 kernels ~492..500 do not include backported patch"
     probe_versions: [ 12.16.0, 12.16.1, 12.16.2, 12.16.3, 12.17.0, 12.17.1 ]
     probe_kinds: [ kmod ]


### PR DESCRIPTION
ignore kernel 6.6 when building driver for agent
release <= 12.17.1.
This applies to both legacy eBPF and kernel module.