### PR TITLE
Update AmazonLinux2 kernel mirrors

### DIFF
--- a/probe_builder/kernel_crawler/amazonlinux.py
+++ b/probe_builder/kernel_crawler/amazonlinux.py
@@ -45,6 +45,7 @@ class AmazonLinux2Mirror(repo.Mirror):
         'core/latest',
         'extras/kernel-5.4/latest',
         'extras/kernel-5.10/latest',
+        'extras/kernel-5.15/latest',
     ]
 
     def list_repos(self, crawler_filter):


### PR DESCRIPTION
Amazon now offers kernel 5.15 on AmazonLinux2 and we need to provide pre-built kernel probes for that kernel version:
```
[root@ip-172-31-7-6 ~]# sudo amazon-linux-extras |grep kernel
  _  kernel-5.4               available    [ =stable ]
 55  kernel-5.10=latest       enabled      [ =stable ]
 62  kernel-5.15              available    [ =stable ]
```

This PR add kernel-5.15 repo