### PR TITLE
fix(crawler): add retry mechanism in case of ConnectionError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='probe_builder',
           'lxml',
           'jinja2',
           'PyYAML',
+          'tenacity',
       ],
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
Some ubuntu crawlings may sometimes fail with the following error: requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))

add a retry mechanism leveraging tenacity to prevent this kind of transient failures from causing the whole
process to bail out entirely.