### PR TITLE
chore: [SMAGENT-6415] exclude broen kernel due to backport

### DIFF
--- a/agent_ignorelist.yaml
+++ b/agent_ignorelist.yaml
@@ -28,6 +28,12 @@ ignorelist:
     matcher: redhat
     skip_if: "{{ (version == '5.14.0' and (rpmrelver|int)>=327) }}"
 
+  - description: "[SMAGENT-6415] kernel 5.14: argument 1 of 'class_create' from incompatible pointer type"
+    probe_versions: [ 12.17.0, 12.17.1, 12.18.0, 12.19.0, 12.20.0 ]
+    probe_kinds: [ kmod, legacy_ebpf ]
+    matcher: redhat
+    skip_if: "{{ (version == '5.14.0' and (rpmrelver|int) >= 410) }}"
+
   - description: "[SMAGENT-4715] 6.2 kernel build"
     probe_versions: [ 12.12.0 ]
     probe_kinds: [ kmod ]


### PR DESCRIPTION
## Changes
 - Exclude kernels that are affected by:
     * `./include/linux/export.h:17:22: error: passing argument 1 of 'class_create' from incompatible pointer type [-Werror=incompatible-pointer-types]`
     * `/code/sysdig-rw/main.c:2875:23: error: too many arguments to function 'class_create'`