### PR TITLE
chore: ignore kernel 6.7 on agent 12.19.0 and older

### DIFF
--- a/agent_ignorelist.yaml
+++ b/agent_ignorelist.yaml
@@ -4,6 +4,12 @@ matchers:
   generic: ^(?P<major>[0-9])\.(?P<minor>[0-9]+)\..*
 
 ignorelist:
+  - description: "Kernel 6.7 on agent <= 12.19.0"
+    probe_versions: [ 12.17.0, 12.17.1, 12.18.0, 12.19.0 ]
+    probe_kinds: [ kmod, legacy_ebpf ]
+    matcher: generic
+    skip_if: "{{ (major|int > 6) or (major|int == 6 and minor|int >= 7) }}"
+
   - description: "[SMAGENT-6088] Kernel 6.6 on agent <= 12.17.1"
     probe_versions: [ 12.15.0, 12.16.0, 12.16.1, 12.16.2, 12.16.3, 12.17.0, 12.17.1 ]
     probe_kinds: [ kmod, legacy_ebpf ]


### PR DESCRIPTION
Kernel 6.7 will cause the following errors on agent 12.19.0

----
kmod
----
 /code/sysdig-rw/ppm_fillers.c: In function 'ppm_get_mm_exe_file':
 /code/sysdig-rw/ppm_fillers.c:549:24: error: 'struct mm_struct' has no member named 'mmap_sem'; did you mean 'mmap_base'?
   549 |         down_read(&mm->mmap_sem);
       |                        ^~~~~~~~
       |                        mmap_base
 /code/sysdig-rw/ppm_fillers.c:553:22: error: 'struct mm_struct' has no member named 'mmap_sem'; did you mean 'mmap_base'?
   553 |         up_read(&mm->mmap_sem);
       |                      ^~~~~~~~
       |                      mmap_base

---
bpf
---

 /code/sysdig-rw/bpf/fillers.h:2855:22: error: no member named 'i_mtime' in 'struct inode'; did you mean '__i_mtime'?
  2855 |         time = _READ(inode->i_mtime);
       |                             ^~~~~~~
       |                             __i_mtime

Both have already been fixed by agent 12.20.0,
so just silence them for older versions.