### PR TITLE
fix(sysdig-probe-loader): tolerate failing rmmod

### DIFF
--- a/sysdig-probe-loader
+++ b/sysdig-probe-loader
@@ -764,7 +764,7 @@ if ([ "$SYSDIG_AGENT_DRIVER" = universal_ebpf ] || [ "$SYSDIG_AGENT_DRIVER" = km
   exit 1
 elif [ "$SYSDIG_AGENT_DRIVER" = universal_ebpf ]; then
   # We don't need the kmod for Universal eBPF
-  /sbin/rmmod "$PROBE_NAME"
+  /sbin/rmmod "$PROBE_NAME" || true
 # Loads the probe
 elif [ "$SYSDIG_AGENT_DRIVER" = legacy_ebpf ] || [ "${SYSDIG_BPF_PROBE+x}" = x ]; then
 	load_bpf_probe


### PR DESCRIPTION
if the probe loader script is invoked with
SYSDIG_AGENT_DRIVER=universal_ebpf
it will try to rmmod the kernel driver,
which might potentially not have been loaded
in the first place.

Tolerate such a failure.