### PR TITLE
[SMAGENT-6644] Handle zstd compression

### DIFF
--- a/sysdig-probe-loader
+++ b/sysdig-probe-loader
@@ -308,16 +308,17 @@ download_kernel_probe() {
 build_kernel_probe() {
 	echo "* Running dkms install for ${PACKAGE_NAME}"
 
-	if bash -x dkms install -m "${PACKAGE_NAME}" -v "${SYSDIG_VERSION}" -k "${KERNEL_RELEASE}"; then
+	if dkms install -m "${PACKAGE_NAME}" -v "${SYSDIG_VERSION}" -k "${KERNEL_RELEASE}"; then
 		echo "  dkms install done"
 
 		echo "* Trying to load the dkms ${PROBE_NAME} via insmod"
+		# Try all possible extensions a kernel module built by dkms can have
 		for ext in ko ko.xz ko.gz ko.zst ; do
-			f="/var/lib/dkms/${PACKAGE_NAME}/${SYSDIG_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.${ext}"
-			echo "* Looking for ${f}"
-			if [ -f $f ]; then
-				echo "* Found ${f}; trying to insmod"
-				if insmod $f > /dev/null 2>&1; then
+			ko_file="/var/lib/dkms/${PACKAGE_NAME}/${SYSDIG_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.${ext}"
+			echo "* Looking for ${ko_file}"
+			if [ -f $ko_file ]; then
+				echo "* Found ${ko_file}; trying to insmod"
+				if insmod $ko_file > /dev/null 2>&1; then
 					echo "  ${PROBE_NAME}.${ext} found and loaded in dkms"
 					return 0
 				fi

--- a/sysdig-probe-loader
+++ b/sysdig-probe-loader
@@ -308,19 +308,22 @@ download_kernel_probe() {
 build_kernel_probe() {
 	echo "* Running dkms install for ${PACKAGE_NAME}"
 
-	if dkms install -m "${PACKAGE_NAME}" -v "${SYSDIG_VERSION}" -k "${KERNEL_RELEASE}"; then
+	if bash -x dkms install -m "${PACKAGE_NAME}" -v "${SYSDIG_VERSION}" -k "${KERNEL_RELEASE}"; then
 		echo "  dkms install done"
 
 		echo "* Trying to load the dkms ${PROBE_NAME} via insmod"
-		if insmod "/var/lib/dkms/${PACKAGE_NAME}/${SYSDIG_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.ko" > /dev/null 2>&1; then
-			echo "  ${PROBE_NAME} found and loaded in dkms"
-			return 0
-		elif insmod "/var/lib/dkms/${PACKAGE_NAME}/${SYSDIG_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.ko.xz" > /dev/null 2>&1; then
-			echo "  ${PROBE_NAME} found and loaded in dkms (xz)"
-			return 0
-		else
-			echo "  Unable to insmod"
-		fi
+		for ext in ko ko.xz ko.gz ko.zst ; do
+			f="/var/lib/dkms/${PACKAGE_NAME}/${SYSDIG_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.${ext}"
+			echo "* Looking for ${f}"
+			if [ -f $f ]; then
+				echo "* Found ${f}; trying to insmod"
+				if insmod $f > /dev/null 2>&1; then
+					echo "  ${PROBE_NAME}.${ext} found and loaded in dkms"
+					return 0
+				fi
+			fi
+		done
+		echo "  Unable to insmod"
 	else
 		DKMS_LOG="/var/lib/dkms/${PACKAGE_NAME}/${SYSDIG_VERSION}/build/make.log"
 		if [ -f "${DKMS_LOG}" ]; then


### PR DESCRIPTION
Starting from Ubuntu 23.10, the default compression method for kernel modules is zstd.
When running the agent-kmodule container on such
host distros, one of two things might happen:

1) If zstd is not installed in the container,
compression will fail:

/usr/sbin/dkms: line 1127: zstd: command not found

This will result in the untouched .ko file
being present under /var/lib/dkms.
So we will find the original .ko file and
the probe loader will be able to install it by
manually picking the path under /var/lib/dkms.

2) If zstd is indeed installed, dkms will destroy
the original .ko file so we won't be able to install it.

Add the necessary plumbing to get the script to
work in the second case.