### PR TITLE
fix(rpm): exclude src arch from rpm kernel crawler

### DIFF
--- a/probe_builder/kernel_crawler/rpm.py
+++ b/probe_builder/kernel_crawler/rpm.py
@@ -37,7 +37,7 @@ class RpmRepository(repo.Repository):
 
     @classmethod
     def kernel_package_query(cls):
-        return '''name IN ('kernel', 'kernel-devel')'''
+        return '''name IN ('kernel', 'kernel-devel') AND arch NOT IN ('src')'''
 
     @classmethod
     def build_base_query(cls, filter=''):


### PR DESCRIPTION
A package named kernel-3.10.0-1160.114.2.el7.src.rpm suddenly
appeared in x86_64 CentOS 7 repositories.
That's a first, since repositories are per-arch and so far have
only contained packages for that arch.
Exclude packages having arch = 'src' when crawling.