### PR TITLE
[SMAGENT-7191] fix(probe-loader): universal ebpf does not require curl

### DIFF
--- a/sysdig-probe-loader
+++ b/sysdig-probe-loader
@@ -750,9 +750,11 @@ if [ "$(id -u)" != 0 ]; then
 	exit 1
 fi
 
-if ! hash curl > /dev/null 2>&1; then
-	echo "This program requires curl"
-	exit 1
+if [ "$SYSDIG_AGENT_DRIVER" != universal_ebpf ]; then
+	if ! hash curl > /dev/null 2>&1; then
+		echo "This program requires curl"
+		exit 1
+	fi
 fi
 
 if [ -v SYSDIG_FORCE_BUILD_PROBE ] && [ -v SYSDIG_FORCE_DOWNLOAD_PROBE ] ; then


### PR DESCRIPTION
# Ticket

https://sysdig.atlassian.net/browse/SMAGENT-7191

# Description

Universal eBPF does not require curl.

Note that curl is required to:
 - download the kmod/bpf probe;
 - download the kernel sources when building the bpf probe (see `build_bpf_probe`).