### PR TITLE
fix(crawler): pin tenacity to 8.3.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='probe_builder',
           'lxml',
           'jinja2',
           'PyYAML',
-          'tenacity',
+          'tenacity==8.3.*',
       ],
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
tenacity 8.4.0 (just released) seems to be broken. Use 8.3.x which has been working fine so far.