### PR TITLE
Add fedora 40 builder to have GCC 14.1

### DIFF
--- a/Dockerfile.centos-gcc14.1-bpf
+++ b/Dockerfile.centos-gcc14.1-bpf
@@ -1,0 +1,22 @@
+FROM fedora:40
+
+RUN yum -y install \
+	wget \
+	git \
+	gcc \
+	gcc-c++ \
+	autoconf \
+	bison \
+	flex \
+	make \
+	cmake \
+	elfutils-devel \
+	findutils \
+	kmod \
+	clang \
+	llvm \
+	python-lxml && yum clean all
+
+ADD builder-entrypoint.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]


### PR DESCRIPTION
This is required to build for the latest kernel 6.9.4-200.fc40.x86_64 and avoid the error:

 gcc: error: unrecognized command-line option '-fmin-function-alignment=16'; did you mean '-flimit-function-alignment'?