### PR TITLE
feat(probe-builder): Ability to crawl EulerOS kernel packages

### DIFF
--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -84,6 +84,7 @@ CLI_DISTROS = {
     'CentOS': CrawlDistro('centos', 'centos', 'CentOS'),
     'CentOSStream': CrawlDistro('centosstream', 'centos', 'CentOSStream'),
     'Debian': CrawlDistro('debian', 'debian', 'Debian'),
+    'EulerOS': CrawlDistro('euleros', 'centos', 'EulerOS'),
     'Fedora': CrawlDistro('fedora', 'centos', 'Fedora'),
     'Flatcar': CrawlDistro('flatcar', 'flatcar', 'Flatcar'),
     'Oracle6': CrawlDistro('oracle6', 'oracle', 'Oracle6'),

--- a/probe_builder/kernel_crawler/__init__.py
+++ b/probe_builder/kernel_crawler/__init__.py
@@ -2,6 +2,7 @@ from .aliyunlinux import AliyunLinuxMirror
 from .almalinux import AlmaLinuxMirror
 from .amazonlinux import AmazonLinux1Mirror, AmazonLinux2Mirror, AmazonLinux2022Mirror
 from .centos import CentosMirror, CentosStreamMirror
+from .euleros import EulerOSMirror
 from .fedora import FedoraMirror
 from .oracle import Oracle6Mirror, Oracle7Mirror, Oracle8Mirror, Oracle9Mirror
 from .photon_os import PhotonOsMirror
@@ -20,6 +21,7 @@ DISTROS = {
     'AmazonLinux2022': AmazonLinux2022Mirror,
     'CentOS': CentosMirror,
     'CentOSStream': CentosStreamMirror,
+    'EulerOS': EulerOSMirror,
     'Fedora': FedoraMirror,
     'Oracle6': Oracle6Mirror,
     'Oracle7': Oracle7Mirror,

--- a/probe_builder/kernel_crawler/euleros.py
+++ b/probe_builder/kernel_crawler/euleros.py
@@ -1,0 +1,19 @@
+from . import repo
+from . import rpm
+
+def v2(ver):
+    return ver.startswith('2')
+
+class EulerOSMirror(repo.Distro):
+    def get_mirrors(self, crawler_filter):
+        mirrors = [
+            # EulerOS 2
+            # Lifecycle:
+            # https://developer.huaweicloud.com/intl/en-us/euleros/lifecycle-management.html
+            # Mirror list:
+            # http://mirrors.huaweicloud.com/euler/
+            rpm.RpmMirror('http://mirrors.huaweicloud.com/euler/', 'os/{}/'.format(crawler_filter.machine), v2),
+            rpm.RpmMirror('http://mirrors.huaweicloud.com/euler/', 'updates/{}/'.format(crawler_filter.machine), v2),
+
+        ]
+        return mirrors

--- a/probe_builder/kernel_crawler/rpm.py
+++ b/probe_builder/kernel_crawler/rpm.py
@@ -118,7 +118,10 @@ class RpmMirror(repo.Mirror):
         dists.raise_for_status()
         dists = dists.content
         doc = html.fromstring(dists, self.base_url)
-        dists = doc.xpath('/html/body//a[not(@href="../")]/@href')
+        # Huawei Cloud loves do things differently
+        # Their page uses a table ouside body tags
+        # this additional filter catch it
+        dists = doc.xpath('/html/body//a[not(@href="../")]/@href | //table/tbody//a[not(@href="../")]/@href')
 
         fdists = [dist for dist in dists
                 if dist.endswith('/')


### PR DESCRIPTION
- Crawl a specific `3.10.x` kernel (EulerOS 2.2)
```
 ➜ docker run --platform=linux/amd64 --rm -v /var/run/docker.sock:/var/run/docker.sock sysdig-probe-builder -C EulerOS "" 3.10.0-327.62.59.83.h87
Checking mirrors of the distro
2024-06-24 19:12:50,876 Dists found under http://mirrors.huaweicloud.com/euler/, filtered by '': ['2.0/', '2.0SP3/', '2.1/', '2.10/', '2.2/', '2.3/', '2.5/', '2.9/']
2024-06-24 19:12:50,878 drel '2' has repos [<probe_builder.kernel_crawler.rpm.RpmRepository object at 0x7ffffd697010>, 
2024-06-24 19:12:54,761 Dists found under http://mirrors.huaweicloud.com/euler/, filtered by '': []
Listing packages
2024-06-24 19:13:12,960 Mirror.get_package_tree() returned packages with the following keys (packages omitted): dict_keys([('2', '3.10.0-327.62.59.83.h87.x86_64')])
=== ('2', '3.10.0-327.62.59.83.h87.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h87.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h87.x86_64.rpm
```

- Crawl a specific `4.18.x` kernel (EulerOS 2.9)
```
Checking mirrors of the distro
2024-06-24 19:16:19,126 Dists found under http://mirrors.huaweicloud.com/euler/, filtered by '': ['2.0/', '2.0SP3/', '2.1/', '2.10/', '2.2/', '2.3/', '2.5/', '2.9/']
2024-06-24 19:16:19,130 drel '2' has repos [<probe_builder.kernel_crawler.rpm.RpmRepository object at 0x7ffffd697010>, 
2024-06-24 19:16:23,622 Dists found under http://mirrors.huaweicloud.com/euler/, filtered by '': []
Listing packages
2024-06-24 19:16:47,369 Mirror.get_package_tree() returned packages with the following keys (packages omitted): dict_keys([('2', '4.18.0-147.5.1.6.h541.eulerosv2r9.x86_64')])
=== ('2', '4.18.0-147.5.1.6.h541.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h541.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h541.eulerosv2r9.x86_64.rpm
```

- Crawl all kernels
```
Checking mirrors of the distro
2024-06-24 19:14:41,357 Dists found under http://mirrors.huaweicloud.com/euler/, filtered by '': ['2.0/', '2.0SP3/', '2.1/', '2.10/', '2.2/', '2.3/', '2.5/', '2.9/']
2024-06-24 19:14:41,358 drel '2' has repos [<probe_builder.kernel_crawler.rpm.RpmRepository object at 0x7ffffd662fb0>, 
2024-06-24 19:14:45,687 Dists found under http://mirrors.huaweicloud.com/euler/, filtered by '': []
Listing packages
2024-06-24 19:15:03,129 Mirror.get_package_tree() returned packages with the following keys (packages omitted): dict_keys([('2', '3.10.0-514.44.5.10.h254.x86_64'), ('2', '4.18.0-147.5.0.5.h116.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.0.5.h126.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.0.7.h156.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.0.h269.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.2.h340.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h1071.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h1136.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h1152.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h1194.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h1305.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h475.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h541.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h579.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h638.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h766.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h841.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h902.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.1.6.h998.eulerosv2r9.x86_64'), ('2', '4.18.0-147.5.2.10.h933.eulerosv2r10.x86_64'), ('2', '4.18.0-147.5.2.13.h996.eulerosv2r10.x86_64'), ('2', '4.18.0-147.5.2.15.h1109.eulerosv2r10.x86_64'), ('2', '4.18.0-147.5.2.19.h1305.eulerosv2r10.x86_64'), ('2', '4.18.0-147.5.2.19.h1404.eulerosv2r10.x86_64'), ('2', '4.18.0-147.5.2.19.h1585.eulerosv2r10.x86_64'), ('2', '3.10.0-327.53.58.73.h3.x86_64'), ('2', '3.10.0-327.59.59.46.h34.x86_64'), ('2', '3.10.0-862.14.0.1.h117.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.0.1.h137.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.0.1.h43.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.0.h183.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h428.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h442.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h470.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h494.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h520.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h591.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h654.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h687.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h708.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h733.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h757.eulerosv2r7.x86_64'), ('2', '3.10.0-862.14.1.5.h816.eulerosv2r7.x86_64'), ('2', '3.10.0-514.41.4.28.h62.x86_64'), ('2', '3.10.0-514.41.4.28.h70.x86_64'), ('2', '3.10.0-514.44.5.10.h121.x86_64'), ('2', '3.10.0-514.44.5.10.h134.x86_64'), ('2', '3.10.0-514.44.5.10.h142.x86_64'), ('2', '3.10.0-514.44.5.10.h165.x86_64'), ('2', '3.10.0-514.44.5.10.h179.x86_64'), ('2', '3.10.0-514.44.5.10.h198.x86_64'), ('2', '3.10.0-514.44.5.10.h234.x86_64'), ('2', '3.10.0-514.44.5.10.h80.x86_64'), ('2', '3.10.0-229.40.1.88.x86_64'), ('2', '3.10.0-229.42.1.104.x86_64'), ('2', '3.10.0-229.42.1.105.x86_64'), ('2', '3.10.0-229.44.1.108.x86_64'), ('2', '3.10.0-229.46.1.111.x86_64'), ('2', '3.10.0-229.46.1.115.x86_64'), ('2', '3.10.0-229.48.1.121.x86_64'), ('2', '3.10.0-229.49.1.127.x86_64'), ('2', '3.10.0-229.49.1.130.x86_64'), ('2', '3.10.0-229.49.1.133.x86_64'), ('2', '3.10.0-229.49.1.135.x86_64'), ('2', '3.10.0-229.49.1.138.x86_64'), ('2', '3.10.0-229.49.1.142.x86_64'), ('2', '3.10.0-229.49.1.149.x86_64'), ('2', '3.10.0-229.49.1.152.x86_64'), ('2', '3.10.0-229.49.1.155.x86_64'), ('2', '3.10.0-229.49.1.157.x86_64'), ('2', '3.10.0-229.49.1.159.x86_64'), ('2', '3.10.0-229.49.1.167.x86_64'), ('2', '3.10.0-229.49.1.170.x86_64'), ('2', '3.10.0-229.49.1.172.x86_64'), ('2', '3.10.0-229.49.1.173.x86_64'), ('2', '3.10.0-229.49.1.175.x86_64'), ('2', '3.10.0-229.49.1.176.x86_64'), ('2', '3.10.0-229.49.1.180.x86_64'), ('2', '3.10.0-229.49.1.185.x86_64'), ('2', '3.10.0-327.36.58.4.x86_64'), ('2', '3.10.0-327.44.58.19.x86_64'), ('2', '3.10.0-327.44.58.28.x86_64'), ('2', '3.10.0-327.44.58.35.x86_64'), ('2', '3.10.0-327.49.58.45.x86_64'), ('2', '3.10.0-327.49.58.52.x86_64'), ('2', '3.10.0-327.53.58.73.h2.x86_64'), ('2', '3.10.0-327.55.58.94.h7.x86_64'), ('2', '3.10.0-327.55.58.94.h9.x86_64'), ('2', '3.10.0-327.58.59.16.h14.x86_64'), ('2', '3.10.0-327.59.59.37.h22.x86_64'), ('2', '3.10.0-327.59.59.46.h27.x86_64'), ('2', '3.10.0-327.59.59.46.h29.x86_64'), ('2', '3.10.0-327.59.59.46.h33.x86_64'), ('2', '3.10.0-327.59.59.46.h35.x86_64'), ('2', '3.10.0-327.59.59.46.h38.x86_64'), ('2', '3.10.0-327.59.59.46.h44.x86_64'), ('2', '3.10.0-327.59.59.46.h49.x86_64'), ('2', '3.10.0-327.59.59.46.h50.x86_64'), ('2', '3.10.0-327.62.59.83.h100.x86_64'), ('2', '3.10.0-327.62.59.83.h108.x86_64'), ('2', '3.10.0-327.62.59.83.h112.x86_64'), ('2', '3.10.0-327.62.59.83.h120.x86_64'), ('2', '3.10.0-327.62.59.83.h128.x86_64'), ('2', '3.10.0-327.62.59.83.h149.x86_64'), ('2', '3.10.0-327.62.59.83.h154.x86_64'), ('2', '3.10.0-327.62.59.83.h162.x86_64'), ('2', '3.10.0-327.62.59.83.h195.x86_64'), ('2', '3.10.0-327.62.59.83.h230.x86_64'), ('2', '3.10.0-327.62.59.83.h243.x86_64'), ('2', '3.10.0-327.62.59.83.h255.x86_64'), ('2', '3.10.0-327.62.59.83.h60.x86_64'), ('2', '3.10.0-327.62.59.83.h65.x86_64'), ('2', '3.10.0-327.62.59.83.h79.x86_64'), ('2', '3.10.0-327.62.59.83.h82.x86_64'), ('2', '3.10.0-327.62.59.83.h87.x86_64'), ('2', '3.10.0-327.62.59.83.h92.x86_64'), ('2', '3.10.0-327.62.59.83.h96.x86_64'), ('2', '3.10.0-327.62.59.83.h98.x86_64')])
=== ('2', '3.10.0-514.44.5.10.h254.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.0SP3/os/x86_64/updates/kernel-devel-3.10.0-514.44.5.10.h254.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.0SP3/os/x86_64/updates/kernel-3.10.0-514.44.5.10.h254.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-devel-3.10.0-514.44.5.10.h254.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-3.10.0-514.44.5.10.h254.x86_64.rpm
=== ('2', '4.18.0-147.5.0.5.h116.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.0.5.h116.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.0.5.h116.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.0.5.h126.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.0.5.h126.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.0.5.h126.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.0.7.h156.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.0.7.h156.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.0.7.h156.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.0.h269.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.0.h269.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.0.h269.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.2.h340.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.2.h340.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.2.h340.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h1071.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h1071.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h1071.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h1136.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h1136.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h1136.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h1152.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h1152.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h1152.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h1194.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h1194.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h1194.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h1305.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h1305.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h1305.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h475.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h475.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h475.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h541.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h541.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h541.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h579.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h579.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h579.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h638.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h638.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h638.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h766.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h766.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h766.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h841.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h841.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h841.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h902.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h902.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h902.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.1.6.h998.eulerosv2r9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-4.18.0-147.5.1.6.h998.eulerosv2r9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.9/os/x86_64/updates/kernel-devel-4.18.0-147.5.1.6.h998.eulerosv2r9.x86_64.rpm
=== ('2', '4.18.0-147.5.2.10.h933.eulerosv2r10.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-4.18.0-147.5.2.10.h933.eulerosv2r10.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-devel-4.18.0-147.5.2.10.h933.eulerosv2r10.x86_64.rpm
=== ('2', '4.18.0-147.5.2.13.h996.eulerosv2r10.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-4.18.0-147.5.2.13.h996.eulerosv2r10.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-devel-4.18.0-147.5.2.13.h996.eulerosv2r10.x86_64.rpm
=== ('2', '4.18.0-147.5.2.15.h1109.eulerosv2r10.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-4.18.0-147.5.2.15.h1109.eulerosv2r10.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-devel-4.18.0-147.5.2.15.h1109.eulerosv2r10.x86_64.rpm
=== ('2', '4.18.0-147.5.2.19.h1305.eulerosv2r10.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-4.18.0-147.5.2.19.h1305.eulerosv2r10.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-devel-4.18.0-147.5.2.19.h1305.eulerosv2r10.x86_64.rpm
=== ('2', '4.18.0-147.5.2.19.h1404.eulerosv2r10.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-4.18.0-147.5.2.19.h1404.eulerosv2r10.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-devel-4.18.0-147.5.2.19.h1404.eulerosv2r10.x86_64.rpm
=== ('2', '4.18.0-147.5.2.19.h1585.eulerosv2r10.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-devel-4.18.0-147.5.2.19.h1585.eulerosv2r10.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.10/os/x86_64/updates/kernel-4.18.0-147.5.2.19.h1585.eulerosv2r10.x86_64.rpm
=== ('2', '3.10.0-327.53.58.73.h3.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.0/os/x86_64/Packages/kernel-3.10.0-327.53.58.73.h3.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.0/os/x86_64/Packages/kernel-devel-3.10.0-327.53.58.73.h3.x86_64.rpm
=== ('2', '3.10.0-327.59.59.46.h34.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.0/os/x86_64/updates/kernel-devel-3.10.0-327.59.59.46.h34.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.0/os/x86_64/updates/kernel-3.10.0-327.59.59.46.h34.x86_64.rpm
=== ('2', '3.10.0-862.14.0.1.h117.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.0.1.h117.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.0.1.h117.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.0.1.h137.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.0.1.h137.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.0.1.h137.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.0.1.h43.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/Packages/kernel-3.10.0-862.14.0.1.h43.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/Packages/kernel-devel-3.10.0-862.14.0.1.h43.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.0.h183.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.0.h183.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.0.h183.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h428.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h428.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h428.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h442.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h442.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h442.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h470.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h470.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h470.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h494.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h494.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h494.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h520.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h520.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h520.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h591.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h591.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h591.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h654.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h654.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h654.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h687.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h687.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h687.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h708.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h708.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h708.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h733.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h733.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h733.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h757.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h757.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h757.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-862.14.1.5.h816.eulerosv2r7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-devel-3.10.0-862.14.1.5.h816.eulerosv2r7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.5/os/x86_64/updates/kernel-3.10.0-862.14.1.5.h816.eulerosv2r7.x86_64.rpm
=== ('2', '3.10.0-514.41.4.28.h62.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/Packages/kernel-devel-3.10.0-514.41.4.28.h62.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/Packages/kernel-3.10.0-514.41.4.28.h62.x86_64.rpm
=== ('2', '3.10.0-514.41.4.28.h70.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-devel-3.10.0-514.41.4.28.h70.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-3.10.0-514.41.4.28.h70.x86_64.rpm
=== ('2', '3.10.0-514.44.5.10.h121.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-devel-3.10.0-514.44.5.10.h121.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-3.10.0-514.44.5.10.h121.x86_64.rpm
=== ('2', '3.10.0-514.44.5.10.h134.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-3.10.0-514.44.5.10.h134.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-devel-3.10.0-514.44.5.10.h134.x86_64.rpm
=== ('2', '3.10.0-514.44.5.10.h142.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-3.10.0-514.44.5.10.h142.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-devel-3.10.0-514.44.5.10.h142.x86_64.rpm
=== ('2', '3.10.0-514.44.5.10.h165.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-3.10.0-514.44.5.10.h165.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-devel-3.10.0-514.44.5.10.h165.x86_64.rpm
=== ('2', '3.10.0-514.44.5.10.h179.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/Packages/kernel-devel-3.10.0-514.44.5.10.h179.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-devel-3.10.0-514.44.5.10.h179.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/Packages/kernel-3.10.0-514.44.5.10.h179.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-3.10.0-514.44.5.10.h179.x86_64.rpm
=== ('2', '3.10.0-514.44.5.10.h198.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-3.10.0-514.44.5.10.h198.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-devel-3.10.0-514.44.5.10.h198.x86_64.rpm
=== ('2', '3.10.0-514.44.5.10.h234.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-devel-3.10.0-514.44.5.10.h234.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-3.10.0-514.44.5.10.h234.x86_64.rpm
=== ('2', '3.10.0-514.44.5.10.h80.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-devel-3.10.0-514.44.5.10.h80.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.3/os/x86_64/updates/kernel-3.10.0-514.44.5.10.h80.x86_64.rpm
=== ('2', '3.10.0-229.40.1.88.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/Packages/kernel-3.10.0-229.40.1.88.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/Packages/kernel-devel-3.10.0-229.40.1.88.x86_64.rpm
=== ('2', '3.10.0-229.42.1.104.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.42.1.104.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.42.1.104.x86_64.rpm
=== ('2', '3.10.0-229.42.1.105.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.42.1.105.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.42.1.105.x86_64.rpm
=== ('2', '3.10.0-229.44.1.108.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.44.1.108.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.44.1.108.x86_64.rpm
=== ('2', '3.10.0-229.46.1.111.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.46.1.111.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.46.1.111.x86_64.rpm
=== ('2', '3.10.0-229.46.1.115.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.46.1.115.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.46.1.115.x86_64.rpm
=== ('2', '3.10.0-229.48.1.121.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.48.1.121.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.48.1.121.x86_64.rpm
=== ('2', '3.10.0-229.49.1.127.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.127.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.127.x86_64.rpm
=== ('2', '3.10.0-229.49.1.130.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.130.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.130.x86_64.rpm
=== ('2', '3.10.0-229.49.1.133.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.133.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.133.x86_64.rpm
=== ('2', '3.10.0-229.49.1.135.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.135.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.135.x86_64.rpm
=== ('2', '3.10.0-229.49.1.138.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.138.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.138.x86_64.rpm
=== ('2', '3.10.0-229.49.1.142.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.142.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.142.x86_64.rpm
=== ('2', '3.10.0-229.49.1.149.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.149.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.149.x86_64.rpm
=== ('2', '3.10.0-229.49.1.152.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.152.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.152.x86_64.rpm
=== ('2', '3.10.0-229.49.1.155.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.155.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.155.x86_64.rpm
=== ('2', '3.10.0-229.49.1.157.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.157.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.157.x86_64.rpm
=== ('2', '3.10.0-229.49.1.159.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.159.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.159.x86_64.rpm
=== ('2', '3.10.0-229.49.1.167.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.167.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.167.x86_64.rpm
=== ('2', '3.10.0-229.49.1.170.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.170.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.170.x86_64.rpm
=== ('2', '3.10.0-229.49.1.172.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.172.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.172.x86_64.rpm
=== ('2', '3.10.0-229.49.1.173.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.173.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.173.x86_64.rpm
=== ('2', '3.10.0-229.49.1.175.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.175.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.175.x86_64.rpm
=== ('2', '3.10.0-229.49.1.176.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.176.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.176.x86_64.rpm
=== ('2', '3.10.0-229.49.1.180.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.180.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.180.x86_64.rpm
=== ('2', '3.10.0-229.49.1.185.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-3.10.0-229.49.1.185.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.1/os/x86_64/updates/kernel-devel-3.10.0-229.49.1.185.x86_64.rpm
=== ('2', '3.10.0-327.36.58.4.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/Packages/kernel-3.10.0-327.36.58.4.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/Packages/kernel-devel-3.10.0-327.36.58.4.x86_64.rpm
=== ('2', '3.10.0-327.44.58.19.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.44.58.19.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.44.58.19.x86_64.rpm
=== ('2', '3.10.0-327.44.58.28.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.44.58.28.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.44.58.28.x86_64.rpm
=== ('2', '3.10.0-327.44.58.35.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.44.58.35.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.44.58.35.x86_64.rpm
=== ('2', '3.10.0-327.49.58.45.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.49.58.45.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.49.58.45.x86_64.rpm
=== ('2', '3.10.0-327.49.58.52.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.49.58.52.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.49.58.52.x86_64.rpm
=== ('2', '3.10.0-327.53.58.73.h2.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.53.58.73.h2.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.53.58.73.h2.x86_64.rpm
=== ('2', '3.10.0-327.55.58.94.h7.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.55.58.94.h7.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.55.58.94.h7.x86_64.rpm
=== ('2', '3.10.0-327.55.58.94.h9.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.55.58.94.h9.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.55.58.94.h9.x86_64.rpm
=== ('2', '3.10.0-327.58.59.16.h14.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.58.59.16.h14.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.58.59.16.h14.x86_64.rpm
=== ('2', '3.10.0-327.59.59.37.h22.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.59.59.37.h22.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.59.59.37.h22.x86_64.rpm
=== ('2', '3.10.0-327.59.59.46.h27.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.59.59.46.h27.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.59.59.46.h27.x86_64.rpm
=== ('2', '3.10.0-327.59.59.46.h29.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.59.59.46.h29.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.59.59.46.h29.x86_64.rpm
=== ('2', '3.10.0-327.59.59.46.h33.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.59.59.46.h33.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.59.59.46.h33.x86_64.rpm
=== ('2', '3.10.0-327.59.59.46.h35.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.59.59.46.h35.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.59.59.46.h35.x86_64.rpm
=== ('2', '3.10.0-327.59.59.46.h38.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.59.59.46.h38.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.59.59.46.h38.x86_64.rpm
=== ('2', '3.10.0-327.59.59.46.h44.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.59.59.46.h44.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.59.59.46.h44.x86_64.rpm
=== ('2', '3.10.0-327.59.59.46.h49.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.59.59.46.h49.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.59.59.46.h49.x86_64.rpm
=== ('2', '3.10.0-327.59.59.46.h50.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.59.59.46.h50.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.59.59.46.h50.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h100.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h100.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h100.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h108.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h108.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h108.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h112.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h112.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h112.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h120.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h120.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h120.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h128.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h128.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h128.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h149.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h149.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h149.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h154.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h154.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h154.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h162.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h162.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h162.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h195.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h195.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h195.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h230.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h230.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h230.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h243.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h243.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h243.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h255.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h255.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h255.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h60.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h60.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h60.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h65.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h65.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h65.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h79.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h79.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h79.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h82.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h82.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h82.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h87.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h87.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h87.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h92.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h92.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h92.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h96.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h96.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h96.x86_64.rpm
=== ('2', '3.10.0-327.62.59.83.h98.x86_64') ===
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-3.10.0-327.62.59.83.h98.x86_64.rpm
 http://mirrors.huaweicloud.com/euler/2.2/os/x86_64/updates/kernel-devel-3.10.0-327.62.59.83.h98.x86_64.rpm
```