### PR TITLE
disable driver creation for kernel 6.11

### DIFF
--- a/agent_ignorelist.yaml
+++ b/agent_ignorelist.yaml
@@ -75,16 +75,10 @@ ignorelist:
     probe_versions: [ 12.20.0, 13.0.0, 13.0.1, 13.0.2, 13.0.3, 13.0.4, 13.1.0, 13.1.1, 13.2.0, 13.2.1, 13.3.0, 13.3.1 ]
     probe_kinds: [ kmod ]
     matcher: generic
-    skip_if: "{{ major|int == 6 and minor|int == 10 }}"
+    skip_if: "{{ major|int == 6 and minor|int >= 10 }}"
 
   - description: "kernel 6.11: no member named '__i_ctime' in 'struct inode'"
     probe_versions: [ 12.20.0, 13.0.0, 13.0.1, 13.0.2, 13.0.3, 13.0.4, 13.1.0, 13.1.1, 13.2.0, 13.2.1, 13.3.0, 13.3.1, 13.3.2, 13.3.3, 13.4.0 ]
     probe_kinds: [ legacy_ebpf ]
-    matcher: generic
-    skip_if: "{{ major|int == 6 and minor|int >= 11 }}"
-
-  - description: "kernel 6.11: implicit declaration of function 'fd_is_open'; did you mean 'finish_open'?"
-    probe_versions: [ 12.20.0, 13.0.0, 13.0.1, 13.0.2, 13.0.3, 13.0.4, 13.1.0, 13.1.1, 13.2.0, 13.2.1, 13.3.0, 13.3.1 ]
-    probe_kinds: [ kmod ]
     matcher: generic
     skip_if: "{{ major|int == 6 and minor|int >= 11 }}"

--- a/agent_ignorelist.yaml
+++ b/agent_ignorelist.yaml
@@ -76,3 +76,15 @@ ignorelist:
     probe_kinds: [ kmod ]
     matcher: generic
     skip_if: "{{ major|int == 6 and minor|int == 10 }}"
+
+  - description: "kernel 6.11: no member named '__i_ctime' in 'struct inode'"
+    probe_versions: [ 12.20.0, 13.0.0, 13.0.1, 13.0.2, 13.0.3, 13.0.4, 13.1.0, 13.1.1, 13.2.0, 13.2.1, 13.3.0, 13.3.1, 13.3.2, 13.3.3, 13.4.0 ]
+    probe_kinds: [ legacy_ebpf ]
+    matcher: generic
+    skip_if: "{{ major|int == 6 and minor|int >= 11 }}"
+
+  - description: "kernel 6.11: implicit declaration of function 'fd_is_open'; did you mean 'finish_open'?"
+    probe_versions: [ 12.20.0, 13.0.0, 13.0.1, 13.0.2, 13.0.3, 13.0.4, 13.1.0, 13.1.1, 13.2.0, 13.2.1, 13.3.0, 13.3.1 ]
+    probe_kinds: [ kmod ]
+    matcher: generic
+    skip_if: "{{ major|int == 6 and minor|int >= 11 }}"


### PR DESCRIPTION
Ubuntu noble started featuring kernel 6.11.0-1001-oem which has the following issues:

a) legacy eBPF

In file included from /code/sysdig-rw/bpf/probe.c:27: /code/sysdig-rw/bpf/fillers.h:2871:22: error: no member named '__i_ctime' in 'struct inode'
        time = _READ(inode->__i_ctime);
                     ~~~~~  ^
/code/sysdig-rw/bpf/plumbing_helpers.h:22:51: note: expanded from macro '_READ'
                    bpf_probe_read_kernel(&_val, sizeof(_val), &P);     \

which then causes other cascading errors
Notice how as today, this issue has not been fixed

b) kmod

/code/sysdig-rw/main.c: In function 'drop_nostate_event': /code/sysdig-rw/main.c:1660:22: error: implicit declaration of function 'fd_is_open'; did you mean 'finish_open'? [-Werror=implicit-function-declaration]
 1660 |                     !fd_is_open(close_fd, fdt)
      |                      ^~~~~~~~~~
      |                      finish_open

This issue has been fixed starting with 13.3.2.