### PR TITLE
chore(debian): add gcc-14 for debian kernels 6.11

### DIFF
--- a/Dockerfile.debian-gcc14.2-bpf
+++ b/Dockerfile.debian-gcc14.2-bpf
@@ -1,0 +1,19 @@
+FROM debian:trixie
+
+RUN apt-get update && apt-get -y --no-install-recommends install \
+	cmake \
+	g++-14 \
+	git \
+	kmod \
+	libc6-dev \
+	libelf-dev \
+	make \
+	pkg-config \
+	clang \
+	llvm \
+	&& apt-get clean
+
+ADD builder-entrypoint.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]
+


### PR DESCRIPTION
Debian kernels 6.11 started failing as they are compiled with gcc-14:

2024-10-12 11:25:41,090 /bin/sh: 1: x86_64-linux-gnu-gcc-14: not found

Add a dedicated builder for it.