### PR TITLE
fix(ubuntu): add builder with gcc13.3

### DIFF
--- a/Dockerfile.ubuntu-gcc13.3-bpf
+++ b/Dockerfile.ubuntu-gcc13.3-bpf
@@ -6,14 +6,14 @@ FROM ubuntu:noble
 # gcc-13/noble,now 13.2.0-23ubuntu4 amd64 [installed,automatic]
 
 RUN for pkg in g++-13 gcc-13 cpp-13 gcc-13-base libgcc-13-dev libobjc-13-dev libstdc++-13-dev; do \
-	echo "Package: $pkg\nPin: version 13.2.*\nPin-Priority: 900\n" \
+	echo "Package: $pkg\nPin: version 13.3.*\nPin-Priority: 900\n" \
 	>> /etc/apt/preferences.d/pin-gcc; done
 
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ noble-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/ubuntu-proposed.list && \
 	apt-get update && \
 	apt-get -y --no-install-recommends install \
 		cmake \
-		g++-13 \
+		g++-13/noble-proposed \
 		git \
 		kmod \
 		libc6-dev \


### PR DESCRIPTION
Recent ubuntu noble kernels (namely: 6.8.0-50-generic) are being compiled with gcc13.3, which is only available through noble-proposed.
So add the appropriate builder for it.

While at it, fix the gcc13.2 builder (currently based on mantic, already out of date) by making it a clone of 13.3, but with the gcc version pinned to 13.2 instead.