### PR TITLE
fix(debian): install fake pahole for kernel 6.12.16

### DIFF
--- a/Dockerfile.debian-gcc14.2-bpf
+++ b/Dockerfile.debian-gcc14.2-bpf
@@ -13,6 +13,9 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 	llvm \
 	&& apt-get clean
 
+# Starting from kernel 6.12.16, pahole seems to be required
+RUN ln -sf /usr/bin/true /usr/bin/pahole
+
 ADD builder-entrypoint.sh /
 WORKDIR /build/probe
 ENTRYPOINT [ "/builder-entrypoint.sh" ]


### PR DESCRIPTION
Starting from kernel 6.12.16, it appears pahole is required to build a kernel module, otherwise the build process will fail. Simply add it as a symlink to true.