### PR TITLE
fix(amazonlinux2023): [SMAGENT-9007] explicitly add kernel6.12

### DIFF
--- a/probe_builder/kernel_crawler/rpm.py
+++ b/probe_builder/kernel_crawler/rpm.py
@@ -37,7 +37,8 @@ class RpmRepository(repo.Repository):
 
     @classmethod
     def kernel_package_query(cls):
-        return '''name IN ('kernel', 'kernel-devel') AND arch NOT IN ('src')'''
+        # XXX kernel6.12 is needed by AmazonLinux 2023.7.20250331
+        return '''name IN ('kernel', 'kernel6.12', 'kernel-devel') AND arch NOT IN ('src')'''
 
     @classmethod
     def build_base_query(cls, filter=''):


### PR DESCRIPTION
Starting with version 2023.7.20250331, AmazonLinux2023 deploys a 6.12 kernel package with a very special name called "kernel6.12", whereas the required headers are in the usual kernel-devel package. The kernel package is required for building the config file's hash, otherwise we get the following:

FileNotFoundError: [Errno 2] No such file or directory: '/workspace/build/amazonlinux2022/6.12.20-23.97.amzn2023.x86_64/lib/modules/6.12.20-23.97.amzn2023.x86_64/config'

So as a workaround, add a kernel6.12 package name to the list of candidate files.