### PR TITLE
fix(amazonlinux2023): [SMAGENT-9029] use builder with gcc11.5

### DIFF
--- a/Dockerfile.centos-gcc11.5-bpf
+++ b/Dockerfile.centos-gcc11.5-bpf
@@ -1,0 +1,22 @@
+FROM amazonlinux:2023.7.20250331.0
+
+RUN yum -y install \
+	wget \
+	git \
+	gcc \
+	gcc-c++ \
+	autoconf \
+	bison \
+	flex \
+	make \
+	cmake \
+	elfutils-devel \
+	findutils \
+	kmod \
+	clang \
+	llvm \
+	python-lxml && yum clean all
+
+ADD builder-entrypoint.sh /
+WORKDIR /build/probe
+ENTRYPOINT [ "/builder-entrypoint.sh" ]


### PR DESCRIPTION
Starting with version 2023.7.20250331, AmazonLinux2023 deploys a 6.12 kernel package compiled with GCC 11.5.0, which on arm64 leverages the option --gsframe, which is apparently not available anywhere else.

This turns out to be available on the latest 2023 AmazonLinux image. So add an explicit builder for gcc 11.5 based on it.