### PR TITLE
[SMAGENT-9129] Implement kernel cache

### DIFF
--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -137,11 +137,13 @@ def prebuild(builder_image_prefix, machine):
 @click.option('-v', '--probe-version')
 @click.option('-m', '--machine', default=os.uname().machine)
 @click.option('-l', '--ignore-list', default='')
+@click.option('--use-cache/--no-use-cache', default=True, help="Use existing cache if available")
+@click.option('--update-cache/--no-update-cache', default=True, help="Update cache with new data")
 @click.argument('package', nargs=-1)
 def build(builder_image_prefix,
           download_concurrency, jobs, kernel_type, distro_filter,
           kernel_filter, probe_name, retries,
-          source_dir, download_timeout, probe_version, machine, ignore_list, package):
+          source_dir, download_timeout, probe_version, machine, ignore_list, use_cache, update_cache, package):
     workspace_dir = os.getcwd()
     builder_source = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -170,12 +172,15 @@ def build(builder_image_prefix,
     # - kernel_filter (e.g. "5.15" to only include kernels starting with 5.15)
 
     cache_file = "kernelcache.yaml"  # Notice the cache file would live in the cwd, i.e. /workspace
-    cache = kernelcache.KernelCache(cache_file)
+    cache = kernelcache.KernelCache(cache_file, load_cache=use_cache)
     cache_key = kernelcache.KernelCache.make_key(kernel_type, machine, distro_filter, kernel_filter)
-    print("Looking up {} in cache".format(cache_key))
-
-    ### ...and also make sure the entry is not too old (e.g. more than 20 hours old) to avoid using stale data
-    cache_entry = cache.get(cache_key, max_duration_hours=20)
+    cache_entry = None
+    if use_cache:
+        print("Looking up {} in cache".format(cache_key))
+        ### ...and also make sure the entry is not too old (e.g. more than 20 hours old) to avoid using stale data
+        cache_entry = cache.get(cache_key, max_duration_hours=20)
+    else:
+        print("Cache disabled, skipping cache lookup")
 
     if cache_entry is not None:
         # If we had a cache hit, use the cached kernels...
@@ -183,8 +188,11 @@ def build(builder_image_prefix,
     else:
         ### ... otherwise, perform the crawl and update the cache
         kernels = distro_obj.get_kernels(workspace, package, download_config, crawler_filter)
-        cache.put(cache_key, kernels)
-        cache.save()
+        if update_cache:
+            cache.put(cache_key, kernels)
+            cache.save()
+        else:
+            print("Cache update disabled, skipping cache update")
 
     kernel_dirs = distro_builder.unpack_kernels(workspace, distro.distro, kernels)
 

--- a/probe_builder/__init__.py
+++ b/probe_builder/__init__.py
@@ -7,7 +7,7 @@ import click
 
 from probe_builder.kernel_crawler import crawl_kernels, DISTROS
 from . import kernel_crawler, disable_ipv6, git, docker
-from .builder import choose_builder, builder_image, ignorelist
+from .builder import choose_builder, builder_image, ignorelist, kernelcache
 from .builder.distro import Distro
 from .context import Context, Workspace, Probe, DownloadConfig
 from concurrent.futures import ThreadPoolExecutor
@@ -162,7 +162,30 @@ def build(builder_image_prefix,
 
     crawler_filter = kernel_crawler.repo.CrawlerFilter(machine=machine, arch=arch, distro_filter=distro_filter, kernel_filter=kernel_filter)
 
-    kernels = distro_obj.get_kernels(workspace, package, download_config, crawler_filter)
+    # Look up the cache to see if we have already performed a crawl for this combination of:
+    # - kernel_type (i.e. ubuntu, amazonlinux, ...)
+    # - machine (x86_64, ...)
+    # - NO NEED TO INCLUDE arch as it would be redundant
+    # - distro_filter (e.g. "resolute" for ubuntu resolute
+    # - kernel_filter (e.g. "5.15" to only include kernels starting with 5.15)
+
+    cache_file = "kernelcache.yaml"  # Notice the cache file would live in the cwd, i.e. /workspace
+    cache = kernelcache.KernelCache(cache_file)
+    cache_key = kernelcache.KernelCache.make_key(kernel_type, machine, distro_filter, kernel_filter)
+    print("Looking up {} in cache".format(cache_key))
+
+    ### ...and also make sure the entry is not too old (e.g. more than 20 hours old) to avoid using stale data
+    cache_entry = cache.get(cache_key, max_duration_hours=20)
+
+    if cache_entry is not None:
+        # If we had a cache hit, use the cached kernels...
+        kernels = cache_entry
+    else:
+        ### ... otherwise, perform the crawl and update the cache
+        kernels = distro_obj.get_kernels(workspace, package, download_config, crawler_filter)
+        cache.put(cache_key, kernels)
+        cache.save()
+
     kernel_dirs = distro_builder.unpack_kernels(workspace, distro.distro, kernels)
 
     with ThreadPoolExecutor(max_workers=jobs) as executor:

--- a/probe_builder/builder/kernelcache.py
+++ b/probe_builder/builder/kernelcache.py
@@ -1,0 +1,62 @@
+import logging
+import time
+import yaml
+
+logger = logging.getLogger(__name__)
+
+class KernelCache:
+    def __init__(self, cachefile):
+        self.cachefile = cachefile
+        self.load()
+
+    def load(self):
+        self.cache = {}
+        yamldoc = None
+        try:
+            with open(self.cachefile, mode="rb") as fp:
+                yamldoc = fp.read()
+        except IOError:
+            logger.warning("cache file {} not found".format(self.cachefile))
+            return
+
+        try:
+            self.cache = yaml.load(yamldoc, Loader=yaml.FullLoader)
+        except yaml.YAMLError as e:
+            logger.warning("failed to parse cache file {}: {}".format(self.cachefile, e))
+
+    def save(self):
+        with open(self.cachefile, mode="w") as fp:
+            yaml.dump(self.cache, fp, default_flow_style=False)
+        logger.debug("cache saved to {}".format(self.cachefile))
+
+    @staticmethod
+    def make_key(kernel_type, machine, distro_filter, kernel_filter):
+        # we use pipes (|) as separators to visually parse the key when looking at the cache file
+        # other alternatives considered which would have worked anyway but would have been less visually clear were:
+        # ":" would create discrepancies with the ":" used in YAML
+        #     (entries with an empty last field i.e. kernel_filter would be quoted, others would not)
+        # "-" might create confusion with the "-" used in kernel filter like "6.19.0-3-generic"
+        return "{}|{}|{}|{}".format(kernel_type, machine, distro_filter, kernel_filter)
+
+    def get(self, key, max_duration_hours):
+        threshold = int(time.time()) - (max_duration_hours * 3600)
+        if key in self.cache:
+            entry = self.cache[key]
+            if entry['ts'] > threshold:
+                logger.debug("cache hit for key {}".format(key))
+                return self.cache[key]["kernels"]
+            else:
+                logger.debug("cache entry {} expired".format(key))
+                del self.cache[key]
+                return None
+        else:
+            logger.debug("cache miss for key {}".format(key))
+            return None
+
+    def put(self, key, kernels):
+        if key in self.cache:
+            logger.debug("cache entry {} already exists".format(key))
+        else:
+            logger.debug("adding cache entry {}".format(key))
+        self.cache[key] = { "ts": int(time.time()), "kernels": kernels }
+

--- a/probe_builder/builder/kernelcache.py
+++ b/probe_builder/builder/kernelcache.py
@@ -25,9 +25,12 @@ class KernelCache:
             logger.warning("failed to parse cache file {}: {}".format(self.cachefile, e))
 
     def save(self):
-        with open(self.cachefile, mode="w") as fp:
-            yaml.dump(self.cache, fp, default_flow_style=False)
-        logger.debug("cache saved to {}".format(self.cachefile))
+        try:
+            with open(self.cachefile, mode="w") as fp:
+                yaml.dump(self.cache, fp, default_flow_style=False)
+            logger.debug("cache saved to {}".format(self.cachefile))
+        except IOError as e:
+            logger.warning("failed to save cache file {}: {}".format(self.cachefile, e))
 
     @staticmethod
     def make_key(kernel_type, machine, distro_filter, kernel_filter):

--- a/probe_builder/builder/kernelcache.py
+++ b/probe_builder/builder/kernelcache.py
@@ -55,7 +55,7 @@ class KernelCache:
 
     def put(self, key, kernels):
         if key in self.cache:
-            logger.debug("cache entry {} already exists".format(key))
+            logger.debug("updating cache entry {}".format(key))
         else:
             logger.debug("adding cache entry {}".format(key))
         self.cache[key] = { "ts": int(time.time()), "kernels": kernels }

--- a/probe_builder/builder/kernelcache.py
+++ b/probe_builder/builder/kernelcache.py
@@ -5,9 +5,11 @@ import yaml
 logger = logging.getLogger(__name__)
 
 class KernelCache:
-    def __init__(self, cachefile):
+    def __init__(self, cachefile, load_cache=True):
         self.cachefile = cachefile
-        self.load()
+        self.cache = {}
+        if load_cache:
+            self.load()
 
     def load(self):
         self.cache = {}


### PR DESCRIPTION
Implement a rudimentary kernel cache that would easily reduce crawling
efforts. Logic is as follows.

A crawl is bound to a specific query, that is: kernel type (aka distro),
architecture, distro filter, kernel filter.

Whenever an actual crawl is successful, save it into the cache
file together with its timestamp.

Whenever a crawl is requested, look up the cache to see if a resultset
is already present with a timestamp no older than 20 hours -- just to
make sure we perform a crawl at least once a day. If one is available,
use it -- otherwise, just proceed as usual with a regular crawl and
cache the resultset to be reused at the next iteration.