### PR TITLE
fix(sysdig-probe-loader): tolerate dkms install failures [SMAGENT-9139]

### DIFF
--- a/sysdig-probe-loader
+++ b/sysdig-probe-loader
@@ -306,10 +306,10 @@ download_kernel_probe() {
 # Returns 0 on success, 1 otherwise.
 #
 build_kernel_probe() {
-	echo "* Running dkms install for ${PACKAGE_NAME}"
+	echo "* Running dkms build for ${PACKAGE_NAME}"
 
-	if dkms install -m "${PACKAGE_NAME}" -v "${SYSDIG_VERSION}" -k "${KERNEL_RELEASE}"; then
-		echo "  dkms install done"
+	if dkms build -m "${PACKAGE_NAME}" -v "${SYSDIG_VERSION}" -k "${KERNEL_RELEASE}"; then
+		echo "  dkms build done"
 
 		echo "* Trying to load the dkms ${PROBE_NAME} via insmod"
 		# Try all possible extensions a kernel module built by dkms can have
@@ -320,6 +320,8 @@ build_kernel_probe() {
 				echo "* Found ${ko_file}; trying to insmod"
 				if insmod $ko_file > /dev/null 2>&1; then
 					echo "  ${PROBE_NAME}.${ext} found and loaded in dkms"
+					echo "* Tentatively running dkms install for ${PACKAGE_NAME}, all errors will be ignored"
+					dkms install -m "${PACKAGE_NAME}" -v "${SYSDIG_VERSION}" -k "${KERNEL_RELEASE}"
 					return 0
 				fi
 			fi

--- a/sysdig-probe-loader
+++ b/sysdig-probe-loader
@@ -320,8 +320,10 @@ build_kernel_probe() {
 				echo "* Found ${ko_file}; trying to insmod"
 				if insmod $ko_file > /dev/null 2>&1; then
 					echo "  ${PROBE_NAME}.${ext} found and loaded in dkms"
-					echo "* Tentatively running dkms install for ${PACKAGE_NAME}, all errors will be ignored"
+					echo "* Tentatively running dkms install for ${PACKAGE_NAME}"
 					dkms install -m "${PACKAGE_NAME}" -v "${SYSDIG_VERSION}" -k "${KERNEL_RELEASE}"
+					echo "* ********************************************"
+
 					return 0
 				fi
 			fi


### PR DESCRIPTION
Historically we've been running 'dkms install' which also tries to copy
the kernel module onto /lib/modules. When running in a container though,
we don't have a writable /lib/modules, so we end up with the following:

Installing /lib/modules/6.8.0-1027-aws/extra/sysdigcloud-probe.ko mkdir:
cannot create directory '/lib/modules/6.8.0-1027-aws/extra': Read-only
file system cp: cannot create regular file
'/lib/modules/6.8.0-1027-aws/extra/sysdigcloud-probe.ko': No such file
or directory

Now, this used to work fine with dkms-3.1.7-3.el9 (except for the above
error messages), whereas with dkms-3.1.8-1.el9 we started getting the
following output accompanied with an error code 6:

Error! Copying
'/var/lib/dkms/draios-agent/<VERSION>/6.8.0-1027-aws/x86_64/module/sysdigcloud-probe.ko'
failed

Since we're not relying on the module being available for automatic
loading (modprobe), but we're explicitly looking for it under dkms'
output directory so to directly insmod it, it becomes apparent we don't
need to 'dkms install' it.

However, there might be situations like native installs where the user
might wish for automatic rebuilds in case of kernel upgrades. So we'll
keep the install as a subsequent, opportunistic step only after we've
confirmed the build and load were successful, ignoring any failures that
might occur at that point.