### PR TITLE
chore(ignorelist): ignore 6.15 kernels for ebpf 14.0.0 [SMAGENT-9355]

### DIFF
--- a/agent_ignorelist.yaml
+++ b/agent_ignorelist.yaml
@@ -95,3 +95,9 @@ ignorelist:
     probe_kinds: [ legacy_ebpf ]
     matcher: generic_aarch64
     skip_if: "{{ (major|int > 6) or (major|int == 6 and minor|int >= 12) }}"
+
+  - description: "kernel 6.15 error: no member named 'parent' in 'struct kernfs_node' [SMAGENT-9355]"
+    probe_versions: [ 13.5.0, 13.6.0, 13.6.1, 13.7.0, 13.7.1, 13.7.2, 13.8.0, 13.8.1, 13.9.0, 13.9.1, 13.9.2, 14.0.0 ]
+    probe_kinds: [ legacy_ebpf ]
+    matcher: generic
+    skip_if: "{{ (major|int > 6) or (major|int == 6 and minor|int >= 15) }}"


### PR DESCRIPTION
./fillers.h:1813:19: error: no member named 'parent' in 'struct kernfs_node'; did you mean '__parent'?
                        kn = _READ(kn->parent);
                                       ^~~~~~
                                       __parent
./plumbing_helpers.h:24:47: note: expanded from macro '_READ'
                bpf_probe_read_kernel(&_val, sizeof(_val), &P); \
                                                            ^
/build/probe/build/ubuntu/6.15.0-3/3/usr/src/linux-headers-6.15.0-3-generic/include/linux/kernfs.h:207:28: note: '__parent' declared here
        struct kernfs_node      __rcu *__parent;
                                       ^