### PR TITLE
[SMAGENT-9558] chore(rpm): debug corrupted sqlite files

### DIFF
--- a/probe_builder/kernel_crawler/download.py
+++ b/probe_builder/kernel_crawler/download.py
@@ -1,5 +1,6 @@
 import bz2
 import zlib
+import zstandard
 import requests
 import traceback
 import shutil
@@ -117,8 +118,15 @@ def get_url(url):
         return lzma.decompress(resp.content)
     elif url.endswith('.bz2'):
         return bz2.decompress(resp.content)
-    else:
+    elif url.endswith('.zst'):
+        dctx = zstandard.ZstdDecompressor()
+        reader = dctx.stream_reader(resp.content)
+        # Read the entire decompressed content
+        return reader.read()
+    elif url.endswith('.sqlite') or url.endswith('.xml'):
         return resp.content
+    else:
+        raise ValueError('Unsupported file format for {}'.format(url))
 
 
 def get_first_of(urls):

--- a/probe_builder/kernel_crawler/rpm.py
+++ b/probe_builder/kernel_crawler/rpm.py
@@ -51,7 +51,7 @@ class RpmRepository(repo.Repository):
             return base_query + ''' AND (version = ? OR version || '-' || "release" = ?)''', (filter, filter)
 
     @classmethod
-    def parse_repo_db(cls, repo_db, filter=''):
+    def parse_repo_db(cls, repo_db, filter='', origin_url='?'):
         db = sqlite3.connect(repo_db)
         cursor = db.cursor()
 
@@ -66,8 +66,11 @@ class RpmRepository(repo.Repository):
             ) SELECT transitive_deps.version, location_href FROM packages INNER JOIN transitive_deps using(pkgkey);
         '''.format(base_query)
 
-        cursor.execute(query, args)
-        return cursor.fetchall()
+        try:
+            cursor.execute(query, args)
+            return cursor.fetchall()
+        except sqlite3.Error as e:
+            raise ValueError("Error parsing repo db at {}: {}".format(origin_url, e))
 
     def get_repodb_url(self):
         repomd_url = self.base_url + 'repodata/repomd.xml'
@@ -90,7 +93,7 @@ class RpmRepository(repo.Repository):
         with tempfile.NamedTemporaryFile() as tf:
             tf.write(repodb)
             tf.flush()
-            for pkg in self.parse_repo_db(tf.name, crawler_filter.kernel_filter):
+            for pkg in self.parse_repo_db(tf.name, crawler_filter.kernel_filter, repodb_url):
                 version, url = pkg
                 packages.setdefault(version, set()).add(self.base_url + url)
         return packages

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='probe_builder',
           'jinja2',
           'PyYAML',
           'tenacity==8.3.*',
+          'zstandard',
       ],
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
Add context (i.e. origin URL) when the sqlite file is unreadable or
corrupted.