### PR TITLE
fix(download): handle all files

### DIFF
--- a/probe_builder/kernel_crawler/download.py
+++ b/probe_builder/kernel_crawler/download.py
@@ -123,10 +123,8 @@ def get_url(url):
         reader = dctx.stream_reader(resp.content)
         # Read the entire decompressed content
         return reader.read()
-    elif url.endswith('.sqlite') or url.endswith('.xml'):
-        return resp.content
     else:
-        raise ValueError('Unsupported file format for {}'.format(url))
+        return resp.content
 
 
 def get_first_of(urls):


### PR DESCRIPTION
The most recent PR #168 wrongly assumed we would only download files from RPM repositories. In fact we download all sorts of files, and this assumption breaks all downloads for all other distros. Revert to the previous behavior, allowing all extensions transparently (except for the compressed ones).