### PR TITLE
fix(amzn2): choose correct builder

### DIFF
--- a/probe_builder/builder/choose_builder.py
+++ b/probe_builder/builder/choose_builder.py
@@ -47,8 +47,9 @@ def choose_distro_dockerfile(builder_source, _builder_distro, kernel_dir):
     if distro_tag is None:
         return
 
-    # if we have a distro tag (e.g. fc34), look for that exact Dockerfile.fc34* (modulo the -bpf suffix)
-    dockerfile = os.path.join(builder_source, 'Dockerfile.{}'.format(distro_tag))
+    # if we have a distro tag (e.g. fc34), look for that exact Dockerfile.fc34-* (modulo the -bpf suffix)
+    # notice how we need the "-" to distinguish between amzn2 and amzn2023
+    dockerfile = os.path.join(builder_source, 'Dockerfile.{}-'.format(distro_tag))
     m = glob.glob(dockerfile+'*')
     if m:
         fn = m[0]


### PR DESCRIPTION
With #158 we introduced a dedicated builder for amzn2023 but this could also be accidentally chosen for amzn2 as it is a valid prefix. On aarch64, this will result in the following:

arch/arm64/Makefile:25: ld does not support --fix-cortex-a53-843419; kernel may be susceptible to erratum
make[2]: gcc10-gcc: No such file or directory

Fix the glob for selection.