### PR TITLE
fix(almalinux): tolerate leading ./ prefix in the distro path

### DIFF
--- a/probe_builder/kernel_crawler/rpm.py
+++ b/probe_builder/kernel_crawler/rpm.py
@@ -129,6 +129,9 @@ class RpmMirror(repo.Mirror):
         doc = html.fromstring(dists, self.base_url)
         dists = doc.xpath('/html/body//a[not(@href="../")]/@href')
 
+        # On 2025-10-09 Almalinux started adding ./ prefix to all paths -- remove it if present
+        dists = [d[2:] if d.startswith('./') else d for d in dists]
+
         fdists = [dist for dist in dists
                 if dist.endswith('/')
                 and not dist.startswith('/')


### PR DESCRIPTION
So far all rpm-based distros have exposed all the available distro
releases using `<a href="x.y/">` items, but now almalinux reports them as
`<a href="./8.4">` items, which do not match our filtering rules.

Just drop the "./" prefix if present.

Notice how now almalinux only exposes the latest "9.x/" version
All others just contain a README.txt placeholder referring to
http://vault.almalinux.org/.