### PR TITLE
chore(ubuntu): ignore 6.14.0-<x>-nvidia

### DIFF
--- a/agent_ignorelist.yaml
+++ b/agent_ignorelist.yaml
@@ -108,4 +108,4 @@ ignorelist:
     probe_versions: [ 13.5.0, 13.6.0, 13.6.1, 13.7.0, 13.7.1, 13.7.2, 13.8.0, 13.8.1, 13.9.0, 13.9.1, 13.9.2, 14.0.0 ]
     probe_kinds: [ legacy_ebpf ]
     matcher: ubuntu_nvidia
-    skip_if: "{{ (version == '6.14.0') and (build == '1012') and (vendor == 'nvidia') }}"
+    skip_if: "{{ (version == '6.14.0') and (build|int >= 1012) and (vendor == 'nvidia') }}"


### PR DESCRIPTION
Follow up on #173.
Turns out 6.14.0-1012-nvidia was not an exception and the backport is here to stay, with a new 6.14.0-1013-nvidia knocking at our doors over the Halloween holidays to trick us into failure again. Let's treat it with respect and ignore it, too.