### PR TITLE
fix(probe-loader): do not set COS_73_WORKAROUND based on version

### DIFF
--- a/sysdig-probe-loader
+++ b/sysdig-probe-loader
@@ -548,15 +548,18 @@ build_bpf_probe() {
 			popd > /dev/null
 
 			# Might need to configure our own sources depending on COS version
-			cos_ver=${BUILD_ID}
-			base_ver=11553.0.0
+			# NOTE: from kernel 6.12 onwards (COS version 19216.0.0), the workaround
+			# is harmful. Since we already have the checks in place in the legacy eBPF
+			# driver setting COS_73_WORKAROUND, this part of the code has been disabled.
+			#cos_ver=${BUILD_ID}
+			#base_ver=11553.0.0
 
-			cos_version_greater
-			greater_ret=$?
+			#cos_version_greater
+			#greater_ret=$?
 
-			if [[ greater_ret -eq 1 ]]; then
-				export KBUILD_EXTRA_CPPFLAGS=-DCOS_73_WORKAROUND
-			fi
+			#if [[ greater_ret -eq 1 ]]; then
+			#	export KBUILD_EXTRA_CPPFLAGS=-DCOS_73_WORKAROUND
+			#fi
 		}
 	fi
 

--- a/sysdig-probe-loader
+++ b/sysdig-probe-loader
@@ -90,54 +90,6 @@
 #   from item B above, to specify a top-level directory (e.g. "dev" instead of "stable")
 # - While retaining/mimicing the standard Sysdig directory structure and filename format
 
-
-#
-# Returns 1 if $cos_ver > $base_ver, 0 otherwise
-#
-cos_version_greater()
-{
-	if [[ $cos_ver == $base_ver ]]; then
-		return 0
-	fi
-
-	#
-	# COS build numbers are in the format x.y.z
-	#
-	a=`echo $cos_ver | cut -d. -f1`
-	b=`echo $cos_ver | cut -d. -f2`
-	c=`echo $cos_ver | cut -d. -f3`
-
-	d=`echo $base_ver | cut -d. -f1`
-	e=`echo $base_ver | cut -d. -f2`
-	f=`echo $base_ver | cut -d. -f3`
-
-	# Test the first component
-	if [[ $a -gt $d ]]; then
-		return 1
-	elif [[ $d -gt $a ]]; then
-		return 0
-	fi
-
-	# Test the second component
-	if [[ $b -gt $e ]]; then
-		return 1
-	elif [[ $e -gt $b ]]; then
-		return 0
-	fi
-
-	# Test the third component
-	if [[ $c -gt $f ]]; then
-		return 1
-	elif [[ $f -gt $c ]]; then
-		return 0
-	fi
-
-	# If we get here, probably malformed version string?
-
-	return 0
-}
-
-
 #
 # Looks for the kernel configuration and stores its hash in KERNEL_CONFIG_PATH.
 # Returns 0 on success, 1 otherwise (cannot find kernel configuration).
@@ -546,20 +498,6 @@ build_bpf_probe() {
 			sed -i '/^#define randomized_struct_fields_end	};$/d' include/linux/compiler-clang.h
 
 			popd > /dev/null
-
-			# Might need to configure our own sources depending on COS version
-			# NOTE: from kernel 6.12 onwards (COS version 19216.0.0), the workaround
-			# is harmful. Since we already have the checks in place in the legacy eBPF
-			# driver setting COS_73_WORKAROUND, this part of the code has been disabled.
-			#cos_ver=${BUILD_ID}
-			#base_ver=11553.0.0
-
-			#cos_version_greater
-			#greater_ret=$?
-
-			#if [[ greater_ret -eq 1 ]]; then
-			#	export KBUILD_EXTRA_CPPFLAGS=-DCOS_73_WORKAROUND
-			#fi
 		}
 	fi
 


### PR DESCRIPTION
We have a check in place which assumes every COS version newer than 11553.0.0 has the divergent changes from mainline kernel requiring our workaround.
Starting from version 19216.0.0 this is no longer the case.

Since the legacy eBPF driver already has the required checks in place, we can simply drop this check and let it handle it automatically by analyzing the source code instead.