### PR TITLE
fix(ubuntu): fix builder images with gcc-13.2/gcc-13.3

### DIFF
--- a/Dockerfile.ubuntu-gcc13.2-bpf
+++ b/Dockerfile.ubuntu-gcc13.2-bpf
@@ -1,15 +1,16 @@
 FROM ubuntu:noble
 
-# Note: as of Nov-2024, ubuntu noble (with proposed) returns:
+# Note: as of Feb-2026, ubuntu noble (without proposed) returns:
 # $ apt list -a gcc-13
-# gcc-13/noble-proposed 13.3.0-6ubuntu2~24.04 amd64
-# gcc-13/noble,now 13.2.0-23ubuntu4 amd64 [installed,automatic]
+# gcc-13/noble-updates 13.3.0-6ubuntu2~24.04.1 amd64
+# gcc-13/noble-security 13.3.0-6ubuntu2~24.04 amd64
+# gcc-13/noble 13.2.0-23ubuntu4 amd64
 
 RUN for pkg in g++-13* gcc-13* cpp-13* libgcc-13-dev libobjc-13-dev libstdc++-13-dev; do \
 	echo "Package: $pkg\nPin: version 13.2.*\nPin-Priority: 900\n" \
 	>> /etc/apt/preferences.d/pin-gcc; done
 
-RUN echo 'deb http://archive.ubuntu.com/ubuntu/ noble-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/ubuntu-proposed.list && \
+RUN \
 	apt-get update && \
 	apt-get -y --no-install-recommends install \
 		cmake \

--- a/Dockerfile.ubuntu-gcc13.3-bpf
+++ b/Dockerfile.ubuntu-gcc13.3-bpf
@@ -1,15 +1,16 @@
 FROM ubuntu:noble
 
-# Note: as of Nov-2024, ubuntu noble (with proposed) returns:
+# Note: as of Feb-2026, ubuntu noble (without proposed) returns:
 # $ apt list -a gcc-13
-# gcc-13/noble-proposed 13.3.0-6ubuntu2~24.04 amd64
-# gcc-13/noble,now 13.2.0-23ubuntu4 amd64 [installed,automatic]
+# gcc-13/noble-updates 13.3.0-6ubuntu2~24.04.1 amd64
+# gcc-13/noble-security 13.3.0-6ubuntu2~24.04 amd64
+# gcc-13/noble 13.2.0-23ubuntu4 amd64
 
 RUN for pkg in g++-13* gcc-13* cpp-13* libgcc-13-dev libobjc-13-dev libstdc++-13-dev; do \
 	echo "Package: $pkg\nPin: version 13.3.*\nPin-Priority: 900\n" \
 	>> /etc/apt/preferences.d/pin-gcc; done
 
-RUN echo 'deb http://archive.ubuntu.com/ubuntu/ noble-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/ubuntu-proposed.list && \
+RUN \
 	apt-get update && \
 	apt-get -y --no-install-recommends install \
 		cmake \


### PR DESCRIPTION
Apparently ubuntu-proposed is no longer present for arm64.

As a matter of fact, gcc-13.3 is now under ubuntu-updates for both amd64 and arm64.

Just drop ubuntu-proposed.