### PR TITLE
fix(ubuntu): fix builder images with gcc-14

### DIFF
--- a/Dockerfile.debian-gcc8.3-bpf
+++ b/Dockerfile.debian-gcc8.3-bpf
@@ -1,6 +1,9 @@
 FROM debian:buster
 
-RUN apt-get update && apt-get -y --no-install-recommends install \
+RUN sed -i -e 's/deb.debian.org/archive.debian.org\/debian-archive/g' /etc/apt/sources.list && \
+    sed -i -e 's/security.debian.org/archive.debian.org\/debian-archive/g' /etc/apt/sources.list && \
+    sed -i '/buster-updates/d' /etc/apt/sources.list && \
+    apt-get update && apt-get -y --no-install-recommends install \
 	cmake \
 	g++ \
 	git \

--- a/Dockerfile.ubuntu-gcc14.2-bpf
+++ b/Dockerfile.ubuntu-gcc14.2-bpf
@@ -1,12 +1,12 @@
 FROM ubuntu:noble
 
-# Note: as of Aug-2024, ubuntu noble returns:
+# Note: as of Feb-2026, ubuntu noble (without proposed) returns:
 # $ apt list -a gcc-14
-# gcc-14/noble,now 14-20240412-0ubuntu1 amd64 [installed,automatic]
-# $ gcc --version
-# gcc (Ubuntu 14-20240412-0ubuntu1) 14.0.1 20240412 (experimental) [master r14-9935-g67e1433a94f]
+# gcc-14/noble-updates 14.2.0-4ubuntu2~24.04.1 amd64
+# gcc-14/noble-security 14.2.0-4ubuntu2~24.04 amd64
+# gcc-14/noble 14-20240412-0ubuntu1 amd64
 
-RUN echo 'deb http://archive.ubuntu.com/ubuntu/ noble-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/ubuntu-proposed.list && \
+RUN \
 	apt-get update && \
 	apt-get -y --no-install-recommends install \
 		cmake \


### PR DESCRIPTION
Followup on #180
Apparently ubuntu-proposed is no longer present.
Just drop ubuntu-proposed.

Also, the default gcc-14 on ubuntu-updates is 14.2. So rename the file accordingly.