### PR TITLE
fix(probe-loader): fix SELinux context for SLES16 [SMAGENT-10385]

### DIFF
--- a/sysdig-probe-loader
+++ b/sysdig-probe-loader
@@ -288,10 +288,10 @@ build_kernel_probe() {
 			ko_file="/var/lib/dkms/${PACKAGE_NAME}/${SYSDIG_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.${ext}"
 			echo "* Looking for ${ko_file}"
 			if [ -f $ko_file ]; then
-				# Fix SELinux context if SELinux is enabled (SLES 16+, RHEL, etc.)
+				# Set proper SELinux context where needed (SLES 16+, RHEL, etc.)
 				if command -v chcon > /dev/null 2>&1 && command -v selinuxenabled > /dev/null 2>&1; then
 					if selinuxenabled 2>/dev/null; then
-						echo "* Fixing SELinux context for ${ko_file}"
+						echo "* Setting SELinux context for ${ko_file}"
 						chcon -t modules_object_t "${ko_file}" 2>/dev/null || true
 					fi
 				fi

--- a/sysdig-probe-loader
+++ b/sysdig-probe-loader
@@ -288,6 +288,13 @@ build_kernel_probe() {
 			ko_file="/var/lib/dkms/${PACKAGE_NAME}/${SYSDIG_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.${ext}"
 			echo "* Looking for ${ko_file}"
 			if [ -f $ko_file ]; then
+				# Fix SELinux context if SELinux is enabled (SLES 16+, RHEL, etc.)
+				if command -v chcon > /dev/null 2>&1 && command -v selinuxenabled > /dev/null 2>&1; then
+					if selinuxenabled 2>/dev/null; then
+						echo "* Fixing SELinux context for ${ko_file}"
+						chcon -t modules_object_t "${ko_file}" 2>/dev/null || true
+					fi
+				fi
 				echo "* Found ${ko_file}; trying to insmod"
 				if insmod $ko_file > /dev/null 2>&1; then
 					echo "  ${PROBE_NAME}.${ext} found and loaded in dkms"


### PR DESCRIPTION
On SLES16, insmod executed by the probe loader (when run from dragent-driver.service unit) fails with 'Permission denied':

insmod: ERROR: could not insert module /var/lib/dkms/.../sysdigcloud-probe.ko.zst: Permission denied

whereas it works fine when executed on the command line.

Upon further investigation, it looks like an issue with SELinux:

journalctl -xe | grep -i selinux

...setroubleshoot[7619]: SELinux is preventing insmod from module_load access on the system /var/lib/dkms/.../sysdigcloud-probe.ko.zst. For complete SELinux messages run: sealert -l
2da2ed16-a73a-4256-9566-3ba3ba15d3ef

which shows:

type=AVC msg=audit(...): avc: denied { module_load } for pid=9260 comm="insmod" path="/var/lib/dkms/.../sysdigcloud-probe.ko.zst" dev="nvme0n1p3" ino=10243
scontext=system_u:system_r:unconfined_service_t:s0 tcontext=unconfined_u:object_r:var_lib_t:s0 tclass=system permissive=0

Simply use chcon to change the context of the newly built .ko.XXX file so to be modules_object_t.